### PR TITLE
Fix NSS log forwarding by attaching correct context

### DIFF
--- a/internal/aad/aad.go
+++ b/internal/aad/aad.go
@@ -48,7 +48,7 @@ func Authenticate(ctx context.Context, tenantID, appID, username, password strin
 	}
 
 	// Authentify the user
-	_, errAcquireToken = app.AcquireTokenByUsernamePassword(context.Background(), nil, username, password)
+	_, errAcquireToken = app.AcquireTokenByUsernamePassword(ctx, nil, username, password)
 
 	var callErr msalErrors.CallErr
 	if errors.As(errAcquireToken, &callErr) {

--- a/internal/cache/passwddb.go
+++ b/internal/cache/passwddb.go
@@ -99,13 +99,13 @@ WHERE p.uid = ?
 
 // NextPasswdEntry returns next passwd from the current position within this cache.
 // It initializes the passwd query on first run and return ErrNoEnt once done.
-func (c *Cache) NextPasswdEntry() (u UserRecord, err error) {
+func (c *Cache) NextPasswdEntry(ctx context.Context) (u UserRecord, err error) {
 	defer func() {
 		if err != nil && !errors.Is(err, ErrNoEnt) {
 			err = fmt.Errorf("failed to read passwd entry in db: %v", err)
 		}
 	}()
-	logger.Debug(context.Background(), "request next passwd entry in db")
+	logger.Debug(ctx, "request next passwd entry in db")
 
 	if c.cursorPasswd == nil {
 		query := `

--- a/internal/cache/shadowdb.go
+++ b/internal/cache/shadowdb.go
@@ -47,13 +47,13 @@ func (c *Cache) GetShadowByName(ctx context.Context, username string) (swr Shado
 
 // NextShadowEntry returns next shadow from the current position within this cache.
 // It initializes the shadow query on first run and return ErrNoEnt once done.
-func (c *Cache) NextShadowEntry() (swr ShadowRecord, err error) {
+func (c *Cache) NextShadowEntry(ctx context.Context) (swr ShadowRecord, err error) {
 	defer func() {
 		if err != nil && !errors.Is(err, ErrNoEnt) {
 			err = fmt.Errorf("failed to read shadow entry in db: %v", err)
 		}
 	}()
-	logger.Debug(context.Background(), "request next shadow entry in db")
+	logger.Debug(ctx, "request next shadow entry in db")
 
 	if c.cursorShadow == nil {
 		query := `

--- a/internal/nss/passwd/passwd.go
+++ b/internal/nss/passwd/passwd.go
@@ -128,7 +128,7 @@ func NextEntry(ctx context.Context) (p Passwd, err error) {
 		return Passwd{}, nss.ErrUnavailableENoEnt
 	}
 
-	u, err := cacheIterateEntries.NextPasswdEntry()
+	u, err := cacheIterateEntries.NextPasswdEntry(ctx)
 	if err != nil {
 		return Passwd{}, nss.ConvertErr(err)
 	}

--- a/internal/nss/shadow/shadow.go
+++ b/internal/nss/shadow/shadow.go
@@ -98,7 +98,7 @@ func NextEntry(ctx context.Context) (sp Shadow, err error) {
 		return Shadow{}, nss.ErrUnavailableENoEnt
 	}
 
-	spw, err := cacheIterateEntries.NextShadowEntry()
+	spw, err := cacheIterateEntries.NextShadowEntry(ctx)
 	if err != nil {
 		return Shadow{}, nss.ConvertErr(err)
 	}


### PR DESCRIPTION
The NSS logs are forwarded to the right destination based on the context
attached. Ensure that we pass the context to anywhere we are writing
logs to that they end up in the journal via syslog.