### PR TITLE
Generate via go generate nss and pam libs

### DIFF
--- a/nss/passwd_c.go
+++ b/nss/passwd_c.go
@@ -17,6 +17,8 @@ import (
 	"github.com/ubuntu/aad-auth/internal/nss/passwd"
 )
 
+//go:generate sh -c "go build -ldflags='-s -w' -buildmode=c-shared -o libnss_aad.so.2"
+
 //export _nss_aad_getpwnam_r
 func _nss_aad_getpwnam_r(name *C.char, pwd *C.struct_passwd, buf *C.char, buflen C.size_t, errnop *C.int) C.nss_status {
 	ctx := ctxWithSyslogLogger(context.Background())

--- a/pam/pam_c.go
+++ b/pam/pam_c.go
@@ -22,7 +22,7 @@ const (
 	defaultConfigPath = "/etc/aad.conf"
 )
 
-//go:generate go build -ldflags="-s -w" -buildmode=c-shared -o pam_aad.so
+//go:generate sh -c "go build -ldflags='-s -w' -buildmode=c-shared -o pam_aad.so"
 
 //export pam_sm_authenticate
 func pam_sm_authenticate(pamh *C.pam_handle_t, flags, argc C.int, argv **C.char) C.int {


### PR DESCRIPTION
Double quotes are handled directly by go:generate, so pass it to a shell
script so that we build our .so files with the correct elements.
This is more a shortcut while we are developping actively the libs. We
will not use go generate for those during package build.