### PR TITLE
Fix segfault while iterating on object with no database

### DIFF
--- a/internal/nss/group/group.go
+++ b/internal/nss/group/group.go
@@ -105,6 +105,7 @@ func StartEntryIteration(ctx context.Context) error {
 func EndEntryIteration(ctx context.Context) error {
 	if cacheIterateEntries == nil {
 		logger.Warn(ctx, "group entry iteration ended without initialization first")
+		return nil
 	}
 	err := cacheIterateEntries.Close()
 	cacheIterateEntries = nil

--- a/internal/nss/passwd/passwd.go
+++ b/internal/nss/passwd/passwd.go
@@ -107,6 +107,7 @@ func StartEntryIteration(ctx context.Context) error {
 func EndEntryIteration(ctx context.Context) error {
 	if cacheIterateEntries == nil {
 		logger.Warn(ctx, "passwd entry iteration ended without initialization first")
+		return nil
 	}
 	err := cacheIterateEntries.Close()
 	cacheIterateEntries = nil

--- a/internal/nss/shadow/shadow.go
+++ b/internal/nss/shadow/shadow.go
@@ -77,6 +77,7 @@ func StartEntryIteration(ctx context.Context) error {
 func EndEntryIteration(ctx context.Context) error {
 	if cacheIterateEntries == nil {
 		logger.Warn(ctx, "shadow entry iteration ended without initialization first")
+		return nil
 	}
 	err := cacheIterateEntries.Close()
 	cacheIterateEntries = nil


### PR DESCRIPTION
If the cache database couldn’t be created for some reasons, we were then
trying to close the whole cache on a nil pointer.
Now, return early to avoid this segfault.

Note that this will change with the new open/close cache logic we will
introduce in the next days.