### PR TITLE
Allow returning api errors while still provide more context.

### DIFF
--- a/internal/nss/group/group.go
+++ b/internal/nss/group/group.go
@@ -33,18 +33,17 @@ func NewByName(ctx context.Context, name string) (g Group, err error) {
 
 	if name == "shadow" {
 		logger.Debug(ctx, "Ignoring shadow group as it's not in our database")
-		return Group{}, nss.ErrNotFoundENoEnt
+		return Group{}, nss.ConvertErr(err)
 	}
 
 	c, err := cache.New(ctx, testopts...)
 	if err != nil {
-		return Group{}, nss.ErrUnavailableENoEnt
+		return Group{}, nss.ConvertErr(err)
 	}
 	defer c.Close()
 
 	grp, err := c.GetGroupByName(ctx, name)
 	if err != nil {
-		// TODO: remove this wrapper and just print logs on error before converting to known format for the C lib.
 		return Group{}, nss.ConvertErr(err)
 	}
 
@@ -69,7 +68,7 @@ func NewByGID(ctx context.Context, gid uint) (g Group, err error) {
 	c, err := cache.New(ctx, testopts...)
 	if err != nil {
 
-		return Group{}, nss.ErrUnavailableENoEnt
+		return Group{}, nss.ConvertErr(err)
 	}
 	defer c.Close()
 
@@ -92,9 +91,7 @@ var cacheIterateEntries *cache.Cache
 func StartEntryIteration(ctx context.Context) error {
 	c, err := cache.New(ctx, testopts...)
 	if err != nil {
-		// TODO: add context to error
-		logger.Warn(ctx, "XXXXXXXXXXX: %v", err)
-		return nss.ErrUnavailableENoEnt
+		return nss.ConvertErr(err)
 	}
 	cacheIterateEntries = c
 
@@ -123,7 +120,7 @@ func NextEntry(ctx context.Context) (g Group, err error) {
 
 	if cacheIterateEntries == nil {
 		logger.Warn(ctx, "group entry iteration called without initialization first")
-		return Group{}, nss.ErrUnavailableENoEnt
+		return Group{}, nss.ConvertErr(err)
 	}
 
 	grp, err := cacheIterateEntries.NextGroupEntry(ctx)

--- a/internal/nss/passwd/passwd.go
+++ b/internal/nss/passwd/passwd.go
@@ -36,8 +36,7 @@ func NewByName(ctx context.Context, name string) (p Passwd, err error) {
 
 	c, err := cache.New(ctx, testopts...)
 	if err != nil {
-		// TODO: wrap all open cache errors OR LOG HERE + transform?
-		return Passwd{}, nss.ErrUnavailableENoEnt
+		return Passwd{}, nss.ConvertErr(err)
 	}
 	defer c.Close()
 
@@ -69,7 +68,7 @@ func NewByUID(ctx context.Context, uid uint) (p Passwd, err error) {
 
 	c, err := cache.New(ctx, testopts...)
 	if err != nil {
-		return Passwd{}, nss.ErrUnavailableENoEnt
+		return Passwd{}, nss.ConvertErr(err)
 	}
 	defer c.Close()
 
@@ -95,8 +94,7 @@ var cacheIterateEntries *cache.Cache
 func StartEntryIteration(ctx context.Context) error {
 	c, err := cache.New(ctx, testopts...)
 	if err != nil {
-		// TODO: add context to error
-		return nss.ErrUnavailableENoEnt
+		return nss.ConvertErr(err)
 	}
 	cacheIterateEntries = c
 
@@ -126,7 +124,7 @@ func NextEntry(ctx context.Context) (p Passwd, err error) {
 
 	if cacheIterateEntries == nil {
 		logger.Warn(ctx, "passwd entry iteration called without initialization first")
-		return Passwd{}, nss.ErrUnavailableENoEnt
+		return Passwd{}, nss.ConvertErr(err)
 	}
 
 	u, err := cacheIterateEntries.NextPasswdEntry()

--- a/internal/nss/shadow/shadow.go
+++ b/internal/nss/shadow/shadow.go
@@ -37,7 +37,7 @@ func NewByName(ctx context.Context, name string) (s Shadow, err error) {
 
 	c, err := cache.New(ctx, testopts...)
 	if err != nil {
-		return Shadow{}, nss.ErrUnavailableENoEnt
+		return Shadow{}, nss.ConvertErr(err)
 	}
 	defer c.Close()
 
@@ -65,8 +65,7 @@ var cacheIterateEntries *cache.Cache
 func StartEntryIteration(ctx context.Context) error {
 	c, err := cache.New(ctx, testopts...)
 	if err != nil {
-		// TODO: add context to error
-		return nss.ErrUnavailableENoEnt
+		return nss.ConvertErr(err)
 	}
 	cacheIterateEntries = c
 
@@ -96,7 +95,7 @@ func NextEntry(ctx context.Context) (sp Shadow, err error) {
 
 	if cacheIterateEntries == nil {
 		logger.Warn(ctx, "shadow entry iteration called without initialization first")
-		return Shadow{}, nss.ErrUnavailableENoEnt
+		return Shadow{}, nss.ConvertErr(err)
 	}
 
 	spw, err := cacheIterateEntries.NextShadowEntry()

--- a/nss/util_c.go
+++ b/nss/util_c.go
@@ -42,11 +42,15 @@ func errToCStatus(ctx context.Context, err error, errnop *C.int) C.nss_status {
 		errno = C.EINVAL
 	}
 
+	if err != nil {
+		logger.Debug(ctx, "%v", err)
+	}
+
 	if errnop != nil {
 		*errnop = C.int(errno)
-		logger.Debug(ctx, "Returning error: %d with errno: %d", nssStatus, errno)
+		logger.Debug(ctx, "Returning to NSS error: %d with errno: %d", nssStatus, errno)
 	} else {
-		logger.Debug(ctx, "Returning error: %d", nssStatus)
+		logger.Debug(ctx, "Returning to NSS error: %d", nssStatus)
 	}
 
 	return nssStatus


### PR DESCRIPTION
We are returning several error type from the cache. However, we can only
return a strict set of error + errno combination to the C NSS api.
Up to now, we were overriding the original error details with the known
set of errors, shadowing thus the original cause. However, we can’t wrap
2 errors at once (only one wrapping a time is allowed), which prevents
us from transforming our error to a known type.
    
This work allow to still return the free-form error, while having an API
defined error embeeded. We thus create our own error data type
(private) with an Unwrap method which will only expose our defined API
errors. Other free-form errors are thus not part of the contract with
the other packages.
However, when printing the error, we still print as debug logs the
underlying error chain details for easier debugging. We separate those
from the error we return to NSS.

Fixes DEENG-327.
