### PR TITLE
Allow reusing cache

### DIFF
--- a/internal/cache/groupdb.go
+++ b/internal/cache/groupdb.go
@@ -106,6 +106,22 @@ func (c *Cache) NextGroupEntry(ctx context.Context) (g GroupRecord, err error) {
 	return newGroupFromScanner(c.cursorGroup)
 }
 
+// CloseGroupIterator allows to close current iterator underlying request group.
+// If none is in process, this is a no-op.
+func (c *Cache) CloseGroupIterator(ctx context.Context) error {
+	logger.Debug(ctx, "request to close group iteration in db")
+	if c.cursorGroup == nil {
+		return nil
+	}
+
+	err := c.cursorGroup.Close()
+	c.cursorGroup = nil
+	if err != nil {
+		return fmt.Errorf("failed to close group iterator in db: %w", err)
+	}
+	return nil
+}
+
 // newGroupFromScanner abstracts the row request deserialization to GroupRecord.
 // It returns ErrNoEnt in case of no element found.
 func newGroupFromScanner(r rowScanner) (g GroupRecord, err error) {

--- a/internal/cache/passwddb.go
+++ b/internal/cache/passwddb.go
@@ -128,6 +128,22 @@ func (c *Cache) NextPasswdEntry(ctx context.Context) (u UserRecord, err error) {
 	return newUserFromScanner(c.cursorPasswd)
 }
 
+// ClosePasswdIterator allows to close current iterator underlying request on passwd.
+// If none is in process, this is a no-op.
+func (c *Cache) ClosePasswdIterator(ctx context.Context) error {
+	logger.Debug(ctx, "request to close passwd iteration in db")
+	if c.cursorPasswd == nil {
+		return nil
+	}
+
+	err := c.cursorPasswd.Close()
+	c.cursorPasswd = nil
+	if err != nil {
+		return fmt.Errorf("failed to close passwd iterator in db: %w", err)
+	}
+	return nil
+}
+
 // newUserFromScanner abstracts the row request deserialization to UserRecord.
 // It returns ErrNoEnt in case of no element found.
 func newUserFromScanner(r rowScanner) (u UserRecord, err error) {

--- a/internal/cache/shadowdb.go
+++ b/internal/cache/shadowdb.go
@@ -78,6 +78,22 @@ func (c *Cache) NextShadowEntry(ctx context.Context) (swr ShadowRecord, err erro
 	return newShadowFromScanner(c.cursorShadow)
 }
 
+// CloseShadowIterator allows to close current iterator underlying request on shadow.
+// If none is in process, this is a no-op.
+func (c *Cache) CloseShadowIterator(ctx context.Context) error {
+	logger.Debug(ctx, "request to close shadow iteration in db")
+	if c.cursorShadow == nil {
+		return nil
+	}
+
+	err := c.cursorShadow.Close()
+	c.cursorShadow = nil
+	if err != nil {
+		return fmt.Errorf("failed to close shadow iterator in db: %w", err)
+	}
+	return nil
+}
+
 // newShadowFromScanner abstracts the row request deserialization to ShadowRecord.
 // It returns ErrNoEnt in case of no element found.
 func newShadowFromScanner(r rowScanner) (swr ShadowRecord, err error) {

--- a/pam/pam.go
+++ b/pam/pam.go
@@ -58,7 +58,7 @@ func authenticate(ctx context.Context, conf string) error {
 		logger.Err(ctx, "%v. Denying access.", err)
 		return ErrPamAuth
 	}
-	defer c.Close()
+	defer c.Close(ctx)
 
 	// No network: try validate user from cache.
 	if errors.Is(errAAD, aad.ErrNoNetwork) {
@@ -94,7 +94,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	defer c.Close()
+	defer c.Close(context.Background())
 
 	for u, pass := range map[string]string{
 		"alice":             "alice pass",


### PR DESCRIPTION
Cache has an underlying db connexion. A new login typically (via NSS)
calls our entries a dozen of times. Instead of everytime opening the db,
checking file permissions, purging the old entries if any, perfom the
request(s) and closing the cache, allow a grace teardown period where
the cache can be reused, and only close it on the last active
connection.

DEENG-324