### PR TITLE
Adding optional parameter for function SaveAndLoadFromGolden

### DIFF
--- a/internal/testutils/goldens.go
+++ b/internal/testutils/goldens.go
@@ -14,10 +14,10 @@ type option struct {
 	goldPath string
 }
 
-// Option ...
+// Option is a supported option reference to change the golden files comparison.
 type Option func(*option)
 
-// WithCustomGoldPath overrides the default path for golden files used
+// WithCustomGoldPath overrides the default path for golden files used.
 func WithCustomGoldPath(path string) Option {
 	return func(o *option) {
 		if path != "" {


### PR DESCRIPTION
Added an optional argument that overrides the path used by the function
to save and load golden files.

I was not sure where I should put the options types and the function, so I left them in the goldens.go file.