### PR TITLE
Authenticater -> Authenticator

### DIFF
--- a/internal/pam/pam.go
+++ b/internal/pam/pam.go
@@ -22,12 +22,12 @@ var (
 	ErrPamIgnore = errors.New("PAM IGNORE")
 )
 
-type Authenticater interface {
+type Authenticator interface {
 	Authenticate(ctx context.Context, cfg config.AAD, username, password string) error
 }
 
 type option struct {
-	auth      Authenticater
+	auth      Authenticator
 	cacheOpts []cache.Option
 }
 
@@ -35,7 +35,7 @@ type option struct {
 type Option func(*option)
 
 // WithAuthenticater overrides the default authenticator.
-func WithAuthenticater(auth Authenticater) Option {
+func WithAuthenticator(auth Authenticator) Option {
 	return func(o *option) {
 		o.auth = auth
 	}

--- a/internal/pam/pam_test.go
+++ b/internal/pam/pam_test.go
@@ -77,7 +77,7 @@ func TestAuthenticate(t *testing.T) {
 			}
 
 			err := pam.Authenticate(context.Background(), tc.username, tc.password, tc.conf,
-				pam.WithAuthenticater(auth),
+				pam.WithAuthenticator(auth),
 				pam.WithCacheOptions(cacheOpts))
 			if tc.wantErrType != nil {
 				require.Error(t, err, "Authenticate should have returned an error but did not")

--- a/pam/pam_testmock.go
+++ b/pam/pam_testmock.go
@@ -52,7 +52,7 @@ func supportedOption(pamLogger *pam.Logger, opt, arg string) bool {
 	case "cachedir":
 		newOpt = pam.WithCacheOptions([]cache.Option{cache.WithCacheDir(arg)})
 	case "mockaad":
-		newOpt = pam.WithAuthenticater(aad.NewWithMockClient())
+		newOpt = pam.WithAuthenticator(aad.NewWithMockClient())
 	default:
 		return false
 	}


### PR DESCRIPTION
Even if most interfaces are finishing up with -er, Rob Pike says so:
https://groups.google.com/g/golang-nuts/c/8xnggK1wo0U
Thanks Gabriel!