### PR TITLE
Fixing an issue with the default homedir

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -125,7 +125,7 @@ func loadDefaultHomeAndShell(ctx context.Context, path string) (home, shell stri
 
 	if tmp := conf.Section("").Key("DHOME").String(); tmp != "" {
 		// DHOME is only the base home directory for all users.
-		dh = filepath.Join(tmp, "%u")
+		dh = filepath.Join(tmp, "%f")
 	}
 	ds = conf.Section("").Key("DSHELL").String()
 

--- a/internal/config/internal_test.go
+++ b/internal/config/internal_test.go
@@ -20,13 +20,13 @@ func TestLoadDefaultHomeAndShell(t *testing.T) {
 	}{
 		"file with both home and shell": {
 			path:      "adduser-both-values.conf",
-			wantHome:  "/home/users/%u",
+			wantHome:  "/home/users/%f",
 			wantShell: "/bin/fish",
 		},
 
 		"file with only dhome": {
 			path:      "adduser-dhome-only.conf",
-			wantHome:  "/home/users/%u",
+			wantHome:  "/home/users/%f",
 			wantShell: "",
 		},
 		"file with only dshell": {


### PR DESCRIPTION
Fixed an issue where, if the homedir was loaded from the adduser.conf
file, the home directory would be set to $DHOME/%u instead of $DHOME/%f,
which is the fully qualified username (user@domain.com)