### PR TITLE
Making the linter duplicate rule more explicit.

### DIFF
--- a/.golangci-ci.yaml
+++ b/.golangci-ci.yaml
@@ -44,12 +44,6 @@ issues:
       - gci
       path: _c\.go
 
-    # Some test and cgo files have look-alike code (specially in nss/), but they are not duplicates, despite the dupl complaining about it.
-    # - linters:
-    #   - dupl
-    #   # path: _(test|c)\.go
-    #   text: ".lines are duplicate of `(nss/*|internal/*)`*"
-
   exclude:
     # EXC0001 errcheck: most errors are in defer calls, which are safe to ignore and idiomatic Go (would be good to only ignore defer ones though)
     - 'Error return value of .((os\.)?std(out|err)\..*|.*Close|.*Flush|os\.Remove(All)?|.*print(f|ln)?|os\.(Un)?Setenv|w\.Stop|logger.Close.*|tx.Rollback*|l.w.*|(passwd|group|shadow).End.*). is not checked'

--- a/.golangci-ci.yaml
+++ b/.golangci-ci.yaml
@@ -45,10 +45,10 @@ issues:
       path: _c\.go
 
     # Some test and cgo files have look-alike code (specially in nss/), but they are not duplicates, despite the dupl complaining about it.
-    - linters:
-      - dupl
-      # path: _(test|c)\.go
-      text: ".lines are duplicate of `(nss/*|internal/*)`*"
+    # - linters:
+    #   - dupl
+    #   # path: _(test|c)\.go
+    #   text: ".lines are duplicate of `(nss/*|internal/*)`*"
 
   exclude:
     # EXC0001 errcheck: most errors are in defer calls, which are safe to ignore and idiomatic Go (would be good to only ignore defer ones though)

--- a/internal/nss/group/group_test.go
+++ b/internal/nss/group/group_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ubuntu/aad-auth/internal/testutils"
 )
 
+//nolint:dupl // TestNewByName and TestNewByGID have similar code that triggers dupl, despite being different.
 func TestNewByName(t *testing.T) {
 	tests := map[string]struct {
 		name         string
@@ -53,6 +54,7 @@ func TestNewByName(t *testing.T) {
 	}
 }
 
+//nolint:dupl // TestNewByName and TestNewByGID have similar code that triggers dupl, despite being different.
 func TestNewByGID(t *testing.T) {
 	tests := map[string]struct {
 		gid          uint

--- a/internal/nss/passwd/passwd_test.go
+++ b/internal/nss/passwd/passwd_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ubuntu/aad-auth/internal/testutils"
 )
 
+//nolint:dupl // TestNewByName and TestNewByGID have similar code that triggers dupl, despite being different.
 func TestNewByName(t *testing.T) {
 	tests := map[string]struct {
 		name         string
@@ -52,6 +53,7 @@ func TestNewByName(t *testing.T) {
 	}
 }
 
+//nolint:dupl // TestNewByName and TestNewByUID have similar code that triggers dupl, despite being different.
 func TestNewByUID(t *testing.T) {
 	tests := map[string]struct {
 		uid          uint

--- a/nss/group_c.go
+++ b/nss/group_c.go
@@ -1,3 +1,4 @@
+//nolint:dupl // nss/(group|passwd|shadow)_c.go files have similar code that triggers dupl, but they are different.
 package main
 
 /*

--- a/nss/group_test.go
+++ b/nss/group_test.go
@@ -9,6 +9,8 @@ import (
 )
 
 // TODO: process coverage once https://github.com/golang/go/issues/51430 is implemented in Go.
+
+//nolint:dupl // TestNssGetGroupByName and TestGetPasswdByName have similar code that triggers dupl, despite being different.
 func TestNssGetGroupByName(t *testing.T) {
 	t.Parallel()
 
@@ -72,6 +74,7 @@ func TestNssGetGroupByName(t *testing.T) {
 	}
 }
 
+//nolint:dupl // TestNssGetGroupByGID and TestGetPasswdByUID have similar code that triggers dupl, despite being different.
 func TestNssGetGroupByGID(t *testing.T) {
 	t.Parallel()
 

--- a/nss/passwd_c.go
+++ b/nss/passwd_c.go
@@ -1,3 +1,4 @@
+//nolint:dupl // nss/(group|passwd|shadow)_c.go files have similar code that triggers dupl, but they are different.
 package main
 
 /*

--- a/nss/passwd_test.go
+++ b/nss/passwd_test.go
@@ -9,6 +9,8 @@ import (
 )
 
 // TODO: process coverage once https://github.com/golang/go/issues/51430 is implemented in Go.
+
+//nolint:dupl // TestNssGetGroupByName and TestGetPasswdByName have similar code that triggers dupl, despite being different.
 func TestNssGetPasswdByName(t *testing.T) {
 	t.Parallel()
 
@@ -71,6 +73,8 @@ func TestNssGetPasswdByName(t *testing.T) {
 		})
 	}
 }
+
+//nolint:dupl // TestNssGetGroupByGID and TestGetPasswdByUID have similar code that triggers dupl, despite being different.
 func TestNssGetPasswdByUID(t *testing.T) {
 	t.Parallel()
 

--- a/nss/shadow_c.go
+++ b/nss/shadow_c.go
@@ -1,3 +1,4 @@
+//nolint:dupl // nss/(group|passwd|shadow)_c.go files have similar code that triggers dupl, but they are different.
 package main
 
 /*


### PR DESCRIPTION
Triggering the linter warns to take a look at how to handle them.