### PR TITLE
Replace SetShadowMode by WithShadowMode in cache tests

### DIFF
--- a/internal/cache/export_test.go
+++ b/internal/cache/export_test.go
@@ -45,11 +45,6 @@ func (c *Cache) WaitForCacheClosed() {
 	}
 }
 
-// SetShadowMode changes the internal recorded state without changing the created files itself.
-func (c *Cache) SetShadowMode(shadowMode int) {
-	c.shadowMode = shadowMode
-}
-
 func (c *Cache) ShadowMode() int {
 	return c.shadowMode
 }

--- a/internal/cache/passwddb_test.go
+++ b/internal/cache/passwddb_test.go
@@ -35,10 +35,9 @@ func TestGetUserByName(t *testing.T) {
 			t.Parallel()
 
 			cacheDir := t.TempDir()
-			testutils.PrepareDBsForTests(t, cacheDir, "users_in_db")
+			testutils.PrepareDBsForTests(t, cacheDir, "users_in_db", cache.WithShadowMode(tc.shadowMode))
 
-			c := testutils.NewCacheForTests(t, cacheDir)
-			c.SetShadowMode(tc.shadowMode)
+			c := testutils.NewCacheForTests(t, cacheDir, cache.WithShadowMode(tc.shadowMode))
 
 			u, err := c.GetUserByName(context.Background(), tc.name)
 			if tc.wantErr {
@@ -98,10 +97,9 @@ func TestGetUserByUID(t *testing.T) {
 			t.Parallel()
 
 			cacheDir := t.TempDir()
-			testutils.PrepareDBsForTests(t, cacheDir, "users_in_db")
+			testutils.PrepareDBsForTests(t, cacheDir, "users_in_db", cache.WithShadowMode(tc.shadowMode))
 
-			c := testutils.NewCacheForTests(t, cacheDir)
-			c.SetShadowMode(tc.shadowMode)
+			c := testutils.NewCacheForTests(t, cacheDir, cache.WithShadowMode(tc.shadowMode))
 
 			u, err := c.GetUserByUID(context.Background(), tc.uid)
 			if tc.wantErr {

--- a/internal/cache/shadowdb_test.go
+++ b/internal/cache/shadowdb_test.go
@@ -34,10 +34,9 @@ func TestGetShadowByName(t *testing.T) {
 			t.Parallel()
 
 			cacheDir := t.TempDir()
-			testutils.PrepareDBsForTests(t, cacheDir, "users_in_db")
+			testutils.PrepareDBsForTests(t, cacheDir, "users_in_db", cache.WithShadowMode(tc.shadowMode))
 
-			c := testutils.NewCacheForTests(t, cacheDir)
-			c.SetShadowMode(tc.shadowMode)
+			c := testutils.NewCacheForTests(t, cacheDir, cache.WithShadowMode(tc.shadowMode))
 
 			s, err := c.GetShadowByName(context.Background(), tc.name)
 			if tc.wantErr {


### PR DESCRIPTION
Now that the db setup inside the tests is refactored, we no longer need to rely on the setShadowMode hack in order to test some functionalities.