### PR TITLE
Removing nss testopts

### DIFF
--- a/internal/nss/group/group.go
+++ b/internal/nss/group/group.go
@@ -18,16 +18,8 @@ type Group struct {
 	members []string /* Members of the group */
 }
 
-var testopts = []cache.Option{}
-
-// setCacheOption set opts everytime we open a cache.
-// This is not compatible with parallel testing as it needs to change a global state.
-func setCacheOption(opts ...cache.Option) {
-	testopts = opts
-}
-
 // NewByName returns a passwd entry from a name.
-func NewByName(ctx context.Context, name string) (g Group, err error) {
+func NewByName(ctx context.Context, name string, cacheOpts ...cache.Option) (g Group, err error) {
 	defer func() {
 		if err != nil {
 			err = fmt.Errorf("failed to get group entry from name %q: %w", name, err)
@@ -41,7 +33,7 @@ func NewByName(ctx context.Context, name string) (g Group, err error) {
 		return Group{}, nss.ErrNotFoundENoEnt
 	}
 
-	c, err := cache.New(ctx, testopts...)
+	c, err := cache.New(ctx, cacheOpts...)
 	if err != nil {
 		return Group{}, nss.ConvertErr(err)
 	}
@@ -61,7 +53,7 @@ func NewByName(ctx context.Context, name string) (g Group, err error) {
 }
 
 // NewByGID returns a group entry from a GID.
-func NewByGID(ctx context.Context, gid uint) (g Group, err error) {
+func NewByGID(ctx context.Context, gid uint, cacheOpts ...cache.Option) (g Group, err error) {
 	defer func() {
 		if err != nil {
 			err = fmt.Errorf("failed to get group entry from GID %d: %w", gid, err)
@@ -70,7 +62,7 @@ func NewByGID(ctx context.Context, gid uint) (g Group, err error) {
 
 	logger.Debug(ctx, "Requesting an group entry matching GID %d", gid)
 
-	c, err := cache.New(ctx, testopts...)
+	c, err := cache.New(ctx, cacheOpts...)
 	if err != nil {
 		return Group{}, nss.ConvertErr(err)
 	}
@@ -93,12 +85,12 @@ var groupIterationCache *cache.Cache
 
 // StartEntryIteration open a new cache for iteration.
 // This needs to be called prior to calling NextEntry and be closed with EndEntryIteration.
-func StartEntryIteration(ctx context.Context) error {
+func StartEntryIteration(ctx context.Context, cacheOpts ...cache.Option) error {
 	if groupIterationCache != nil {
 		return nss.ConvertErr(errors.New("group entry iteration already in progress. End it before starting a new one"))
 	}
 
-	c, err := cache.New(ctx, testopts...)
+	c, err := cache.New(ctx, cacheOpts...)
 	if err != nil {
 		return nss.ConvertErr(err)
 	}

--- a/internal/nss/group/group_test.go
+++ b/internal/nss/group/group_test.go
@@ -14,6 +14,8 @@ import (
 
 //nolint:dupl // TestNewByName and TestNewByGID have similar code that triggers dupl, despite being different.
 func TestNewByName(t *testing.T) {
+	t.Parallel()
+
 	tests := map[string]struct {
 		name         string
 		failingCache bool
@@ -30,6 +32,8 @@ func TestNewByName(t *testing.T) {
 	for name, tc := range tests {
 		tc := tc
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
 			cacheDir := t.TempDir()
 			testutils.PrepareDBsForTests(t, cacheDir, "users_in_db")
 
@@ -38,9 +42,8 @@ func TestNewByName(t *testing.T) {
 			if tc.failingCache {
 				opts = append(opts, cache.WithRootUID(4242))
 			}
-			group.SetCacheOption(opts...)
 
-			got, err := group.NewByName(context.Background(), tc.name)
+			got, err := group.NewByName(context.Background(), tc.name, opts...)
 			if tc.wantErrType != nil {
 				require.Error(t, err, "NewByName should have returned an error and hasn’t")
 				require.ErrorIs(t, err, tc.wantErrType, "NewByName has not returned expected error type")
@@ -56,6 +59,8 @@ func TestNewByName(t *testing.T) {
 
 //nolint:dupl // TestNewByName and TestNewByGID have similar code that triggers dupl, despite being different.
 func TestNewByGID(t *testing.T) {
+	t.Parallel()
+
 	tests := map[string]struct {
 		gid          uint
 		failingCache bool
@@ -71,6 +76,8 @@ func TestNewByGID(t *testing.T) {
 	for name, tc := range tests {
 		tc := tc
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
 			cacheDir := t.TempDir()
 			testutils.PrepareDBsForTests(t, cacheDir, "users_in_db")
 
@@ -79,9 +86,8 @@ func TestNewByGID(t *testing.T) {
 			if tc.failingCache {
 				opts = append(opts, cache.WithRootUID(4242))
 			}
-			group.SetCacheOption(opts...)
 
-			got, err := group.NewByGID(context.Background(), tc.gid)
+			got, err := group.NewByGID(context.Background(), tc.gid, opts...)
 			if tc.wantErrType != nil {
 				require.Error(t, err, "NewByGID should have returned an error and hasn’t")
 				require.ErrorIs(t, err, tc.wantErrType, "NewByGID has not returned expected error type")
@@ -96,6 +102,8 @@ func TestNewByGID(t *testing.T) {
 }
 
 func TestNextEntry(t *testing.T) {
+	t.Parallel()
+
 	tests := map[string]struct {
 		numNextIteration int
 		hasNoGroup       bool
@@ -113,6 +121,8 @@ func TestNextEntry(t *testing.T) {
 	for name, tc := range tests {
 		tc := tc
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
 			cacheDir := t.TempDir()
 			if !tc.hasNoGroup {
 				testutils.PrepareDBsForTests(t, cacheDir, "users_in_db")
@@ -120,10 +130,9 @@ func TestNextEntry(t *testing.T) {
 
 			uid, gid := testutils.GetCurrentUIDGID(t)
 			opts := []cache.Option{cache.WithCacheDir(cacheDir), cache.WithRootUID(uid), cache.WithRootGID(gid), cache.WithShadowGID(gid)}
-			group.SetCacheOption(opts...)
 
 			if !tc.noIterationInit {
-				err := group.StartEntryIteration(context.Background())
+				err := group.StartEntryIteration(context.Background(), opts...)
 				require.NoError(t, err, "StartEntryIteration should succeed")
 				defer group.EndEntryIteration(context.Background())
 			}
@@ -155,6 +164,8 @@ func TestNextEntry(t *testing.T) {
 }
 
 func TestStartEndEntryIteration(t *testing.T) {
+	t.Parallel()
+
 	tests := map[string]struct {
 		alreadyIterationInProgress bool
 		noStartIteration           bool
@@ -172,14 +183,15 @@ func TestStartEndEntryIteration(t *testing.T) {
 	for name, tc := range tests {
 		tc := tc
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
 			cacheDir := t.TempDir()
 
 			uid, gid := testutils.GetCurrentUIDGID(t)
 			opts := []cache.Option{cache.WithCacheDir(cacheDir), cache.WithRootUID(uid), cache.WithRootGID(gid), cache.WithShadowGID(gid)}
-			group.SetCacheOption(opts...)
 
 			if tc.alreadyIterationInProgress {
-				err := group.StartEntryIteration(context.Background())
+				err := group.StartEntryIteration(context.Background(), opts...)
 				require.NoError(t, err, "Setup: first startEntryIteration should have failed by hasn’t")
 				defer group.EndEntryIteration(context.Background())
 			}
@@ -187,10 +199,9 @@ func TestStartEndEntryIteration(t *testing.T) {
 			if tc.cacheOpenError {
 				opts = append(opts, cache.WithRootUID(4242))
 			}
-			group.SetCacheOption(opts...)
 
 			if !tc.noStartIteration {
-				err := group.StartEntryIteration(context.Background())
+				err := group.StartEntryIteration(context.Background(), opts...)
 				if tc.wantStartIterationErr {
 					require.Error(t, err, "StartEntryIteration should have failed by hasn’t")
 					require.ErrorIs(t, err, nss.ErrUnavailableENoEnt, "Error should be of type Unavailable")
@@ -206,15 +217,16 @@ func TestStartEndEntryIteration(t *testing.T) {
 }
 
 func TestRestartIterationWithoutEndingPreviousOne(t *testing.T) {
+	t.Parallel()
+
 	cacheDir := t.TempDir()
 	testutils.PrepareDBsForTests(t, cacheDir, "users_in_db")
 
 	uid, gid := testutils.GetCurrentUIDGID(t)
 	opts := []cache.Option{cache.WithCacheDir(cacheDir), cache.WithRootUID(uid), cache.WithRootGID(gid), cache.WithShadowGID(gid)}
-	group.SetCacheOption(opts...)
 
 	// First iteration group
-	err := group.StartEntryIteration(context.Background())
+	err := group.StartEntryIteration(context.Background(), opts...)
 	require.NoError(t, err, "StartEntryIteration should succeed")
 	defer group.EndEntryIteration(context.Background()) // in case of an error in the middle of the test. No-op otherwise
 
@@ -226,7 +238,7 @@ func TestRestartIterationWithoutEndingPreviousOne(t *testing.T) {
 	require.NoError(t, err, "EndEntryIteration while iterating should work")
 
 	// Second iteration group
-	err = group.StartEntryIteration(context.Background())
+	err = group.StartEntryIteration(context.Background(), opts...)
 	require.NoError(t, err, "restart a second entry iteration should succeed")
 	defer group.EndEntryIteration(context.Background())
 

--- a/internal/nss/group/integrationtests.go
+++ b/internal/nss/group/integrationtests.go
@@ -1,6 +1,0 @@
-//go:build integrationtests
-
-package group
-
-// Expose setCacheOption for integration tests
-var SetCacheOption = setCacheOption

--- a/internal/nss/group/package_test.go
+++ b/internal/nss/group/package_test.go
@@ -1,6 +1,0 @@
-//go:build !integrationtests
-
-package group
-
-// Expose setCacheOption for package tests.
-var SetCacheOption = setCacheOption

--- a/internal/nss/passwd/integrationtests.go
+++ b/internal/nss/passwd/integrationtests.go
@@ -1,6 +1,0 @@
-//go:build integrationtests
-
-package passwd
-
-// Expose setCacheOption for integration tests
-var SetCacheOption = setCacheOption

--- a/internal/nss/passwd/package_test.go
+++ b/internal/nss/passwd/package_test.go
@@ -1,6 +1,0 @@
-//go:build !integrationtests
-
-package passwd
-
-// Expose setCacheOption for package tests.
-var SetCacheOption = setCacheOption

--- a/internal/nss/passwd/passwd.go
+++ b/internal/nss/passwd/passwd.go
@@ -21,16 +21,8 @@ type Passwd struct {
 	shell  string /* shell program */
 }
 
-var testopts = []cache.Option{}
-
-// setCacheOption set opts everytime we open a cache.
-// This is not compatible with parallel testing as it needs to change a global state.
-func setCacheOption(opts ...cache.Option) {
-	testopts = opts
-}
-
 // NewByName returns a passwd entry from a name.
-func NewByName(ctx context.Context, name string) (p Passwd, err error) {
+func NewByName(ctx context.Context, name string, cacheOpts ...cache.Option) (p Passwd, err error) {
 	defer func() {
 		if err != nil {
 			err = fmt.Errorf("failed to get passwd entry from name %q: %w", name, err)
@@ -39,7 +31,7 @@ func NewByName(ctx context.Context, name string) (p Passwd, err error) {
 
 	logger.Debug(ctx, "Requesting a passwd entry matching name %q", name)
 
-	c, err := cache.New(ctx, testopts...)
+	c, err := cache.New(ctx, cacheOpts...)
 	if err != nil {
 		return Passwd{}, nss.ConvertErr(err)
 	}
@@ -62,7 +54,7 @@ func NewByName(ctx context.Context, name string) (p Passwd, err error) {
 }
 
 // NewByUID returns a passwd entry from an UID.
-func NewByUID(ctx context.Context, uid uint) (p Passwd, err error) {
+func NewByUID(ctx context.Context, uid uint, cacheOpts ...cache.Option) (p Passwd, err error) {
 	defer func() {
 		if err != nil {
 			err = fmt.Errorf("failed to get passwd entry from UID %d: %w", uid, err)
@@ -71,7 +63,7 @@ func NewByUID(ctx context.Context, uid uint) (p Passwd, err error) {
 
 	logger.Debug(ctx, "Requesting a passwd entry matching UID %d", uid)
 
-	c, err := cache.New(ctx, testopts...)
+	c, err := cache.New(ctx, cacheOpts...)
 	if err != nil {
 		return Passwd{}, nss.ConvertErr(err)
 	}
@@ -97,12 +89,12 @@ var passwdIterationCache *cache.Cache
 
 // StartEntryIteration open a new cache for iteration.
 // This needs to be called prior to calling NextEntry and be closed with EndEntryIteration.
-func StartEntryIteration(ctx context.Context) error {
+func StartEntryIteration(ctx context.Context, cacheOpts ...cache.Option) error {
 	if passwdIterationCache != nil {
 		return nss.ConvertErr(errors.New("passwd entry iteration already in progress. End it before starting a new one"))
 	}
 
-	c, err := cache.New(ctx, testopts...)
+	c, err := cache.New(ctx, cacheOpts...)
 	if err != nil {
 		return nss.ConvertErr(err)
 	}

--- a/internal/nss/passwd/passwd_test.go
+++ b/internal/nss/passwd/passwd_test.go
@@ -14,6 +14,8 @@ import (
 
 //nolint:dupl // TestNewByName and TestNewByGID have similar code that triggers dupl, despite being different.
 func TestNewByName(t *testing.T) {
+	t.Parallel()
+
 	tests := map[string]struct {
 		name         string
 		failingCache bool
@@ -29,6 +31,8 @@ func TestNewByName(t *testing.T) {
 	for name, tc := range tests {
 		tc := tc
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
 			cacheDir := t.TempDir()
 			testutils.PrepareDBsForTests(t, cacheDir, "users_in_db")
 
@@ -37,9 +41,8 @@ func TestNewByName(t *testing.T) {
 			if tc.failingCache {
 				opts = append(opts, cache.WithRootUID(4242))
 			}
-			passwd.SetCacheOption(opts...)
 
-			got, err := passwd.NewByName(context.Background(), tc.name)
+			got, err := passwd.NewByName(context.Background(), tc.name, opts...)
 			if tc.wantErrType != nil {
 				require.Error(t, err, "NewByName should have returned an error and hasn’t")
 				require.ErrorIs(t, err, tc.wantErrType, "NewByName has not returned expected error type")
@@ -55,6 +58,8 @@ func TestNewByName(t *testing.T) {
 
 //nolint:dupl // TestNewByName and TestNewByUID have similar code that triggers dupl, despite being different.
 func TestNewByUID(t *testing.T) {
+	t.Parallel()
+
 	tests := map[string]struct {
 		uid          uint
 		failingCache bool
@@ -70,6 +75,8 @@ func TestNewByUID(t *testing.T) {
 	for name, tc := range tests {
 		tc := tc
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
 			cacheDir := t.TempDir()
 			testutils.PrepareDBsForTests(t, cacheDir, "users_in_db")
 
@@ -78,9 +85,8 @@ func TestNewByUID(t *testing.T) {
 			if tc.failingCache {
 				opts = append(opts, cache.WithRootUID(4242))
 			}
-			passwd.SetCacheOption(opts...)
 
-			got, err := passwd.NewByUID(context.Background(), tc.uid)
+			got, err := passwd.NewByUID(context.Background(), tc.uid, opts...)
 			if tc.wantErrType != nil {
 				require.Error(t, err, "NewByUID should have returned an error and hasn’t")
 				require.ErrorIs(t, err, tc.wantErrType, "NewByUID has not returned expected error type")
@@ -95,6 +101,8 @@ func TestNewByUID(t *testing.T) {
 }
 
 func TestNextEntry(t *testing.T) {
+	t.Parallel()
+
 	tests := map[string]struct {
 		numNextIteration int
 		hasNoUser        bool
@@ -112,6 +120,8 @@ func TestNextEntry(t *testing.T) {
 	for name, tc := range tests {
 		tc := tc
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
 			cacheDir := t.TempDir()
 			if !tc.hasNoUser {
 				testutils.PrepareDBsForTests(t, cacheDir, "users_in_db")
@@ -119,10 +129,9 @@ func TestNextEntry(t *testing.T) {
 
 			uid, gid := testutils.GetCurrentUIDGID(t)
 			opts := []cache.Option{cache.WithCacheDir(cacheDir), cache.WithRootUID(uid), cache.WithRootGID(gid), cache.WithShadowGID(gid)}
-			passwd.SetCacheOption(opts...)
 
 			if !tc.noIterationInit {
-				err := passwd.StartEntryIteration(context.Background())
+				err := passwd.StartEntryIteration(context.Background(), opts...)
 				require.NoError(t, err, "StartEntryIteration should succeed")
 				defer passwd.EndEntryIteration(context.Background())
 			}
@@ -154,6 +163,8 @@ func TestNextEntry(t *testing.T) {
 }
 
 func TestStartEndEntryIteration(t *testing.T) {
+	t.Parallel()
+
 	tests := map[string]struct {
 		alreadyIterationInProgress bool
 		noStartIteration           bool
@@ -171,14 +182,15 @@ func TestStartEndEntryIteration(t *testing.T) {
 	for name, tc := range tests {
 		tc := tc
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
 			cacheDir := t.TempDir()
 
 			uid, gid := testutils.GetCurrentUIDGID(t)
 			opts := []cache.Option{cache.WithCacheDir(cacheDir), cache.WithRootUID(uid), cache.WithRootGID(gid), cache.WithShadowGID(gid)}
-			passwd.SetCacheOption(opts...)
 
 			if tc.alreadyIterationInProgress {
-				err := passwd.StartEntryIteration(context.Background())
+				err := passwd.StartEntryIteration(context.Background(), opts...)
 				require.NoError(t, err, "Setup: first startEntryIteration should have failed by hasn’t")
 				defer passwd.EndEntryIteration(context.Background())
 			}
@@ -186,10 +198,9 @@ func TestStartEndEntryIteration(t *testing.T) {
 			if tc.cacheOpenError {
 				opts = append(opts, cache.WithRootUID(4242))
 			}
-			passwd.SetCacheOption(opts...)
 
 			if !tc.noStartIteration {
-				err := passwd.StartEntryIteration(context.Background())
+				err := passwd.StartEntryIteration(context.Background(), opts...)
 				if tc.wantStartIterationErr {
 					require.Error(t, err, "StartEntryIteration should have failed by hasn’t")
 					require.ErrorIs(t, err, nss.ErrUnavailableENoEnt, "Error should be of type Unavailable")
@@ -205,15 +216,16 @@ func TestStartEndEntryIteration(t *testing.T) {
 }
 
 func TestRestartIterationWithoutEndingPreviousOne(t *testing.T) {
+	t.Parallel()
+
 	cacheDir := t.TempDir()
 	testutils.PrepareDBsForTests(t, cacheDir, "users_in_db")
 
 	uid, gid := testutils.GetCurrentUIDGID(t)
 	opts := []cache.Option{cache.WithCacheDir(cacheDir), cache.WithRootUID(uid), cache.WithRootGID(gid), cache.WithShadowGID(gid)}
-	passwd.SetCacheOption(opts...)
 
 	// First iteration group
-	err := passwd.StartEntryIteration(context.Background())
+	err := passwd.StartEntryIteration(context.Background(), opts...)
 	require.NoError(t, err, "StartEntryIteration should succeed")
 	defer passwd.EndEntryIteration(context.Background()) // in case of an error in the middle of the test. No-op otherwise
 
@@ -225,7 +237,7 @@ func TestRestartIterationWithoutEndingPreviousOne(t *testing.T) {
 	require.NoError(t, err, "EndEntryIteration while iterating should work")
 
 	// Second iteration group
-	err = passwd.StartEntryIteration(context.Background())
+	err = passwd.StartEntryIteration(context.Background(), opts...)
 	require.NoError(t, err, "restart a second entry iteration should succeed")
 	defer passwd.EndEntryIteration(context.Background())
 

--- a/internal/nss/shadow/integrationtests.go
+++ b/internal/nss/shadow/integrationtests.go
@@ -1,6 +1,0 @@
-//go:build integrationtests
-
-package shadow
-
-// Expose setCacheOption for integration tests
-var SetCacheOption = setCacheOption

--- a/internal/nss/shadow/package_test.go
+++ b/internal/nss/shadow/package_test.go
@@ -1,6 +1,0 @@
-//go:build !integrationtests
-
-package shadow
-
-// Expose setCacheOption for package tests.
-var SetCacheOption = setCacheOption

--- a/nss/group_c.go
+++ b/nss/group_c.go
@@ -28,7 +28,7 @@ func _nss_aad_getgrnam_r(name *C.char, grp *C.struct_group, buf *C.char, buflen 
 	logger.Debug(ctx, "_nss_aad_getgrname_r called for %q", n)
 	n = user.NormalizeName(n)
 
-	p, err := group.NewByName(ctx, n)
+	p, err := group.NewByName(ctx, n, opts...)
 	if err != nil {
 		return errToCStatus(ctx, err, errnop)
 	}
@@ -45,7 +45,7 @@ func _nss_aad_getgrgid_r(gid C.gid_t, grp *C.struct_group, buf *C.char, buflen C
 	defer logger.CloseLoggerFromContext(ctx)
 	logger.Debug(ctx, "_nss_aad_getgrgid_r called for %d", gid)
 
-	g, err := group.NewByGID(ctx, uint(gid))
+	g, err := group.NewByGID(ctx, uint(gid), opts...)
 	if err != nil {
 		return errToCStatus(ctx, err, errnop)
 	}
@@ -62,7 +62,7 @@ func _nss_aad_setgrent(stayopen C.int) C.nss_status {
 	defer logger.CloseLoggerFromContext(ctx)
 	logger.Debug(ctx, "_nss_aad_setgrent called")
 
-	err := group.StartEntryIteration(ctx)
+	err := group.StartEntryIteration(ctx, opts...)
 	if err != nil {
 		return errToCStatus(ctx, err, nil)
 	}

--- a/nss/nss.go
+++ b/nss/nss.go
@@ -1,7 +1,11 @@
 package main
 
+import (
+	"github.com/ubuntu/aad-auth/internal/cache"
+)
+
 var (
-// opts []nss.Option
+	opts = []cache.Option{}
 )
 
 func main() {

--- a/nss/nss_dboverride.go
+++ b/nss/nss_dboverride.go
@@ -8,9 +8,6 @@ import (
 	"strconv"
 
 	"github.com/ubuntu/aad-auth/internal/cache"
-	"github.com/ubuntu/aad-auth/internal/nss/group"
-	"github.com/ubuntu/aad-auth/internal/nss/passwd"
-	"github.com/ubuntu/aad-auth/internal/nss/shadow"
 )
 
 /*
@@ -30,8 +27,6 @@ import "C"
 
 // initialize via env variables in mock test
 func init() {
-	var opts []cache.Option
-
 	uidEnv := os.Getenv("NSS_AAD_ROOT_UID")
 	if uidEnv != "" {
 		uid, err := strconv.Atoi(uidEnv)
@@ -66,8 +61,4 @@ func init() {
 		}
 		opts = append(opts, cache.WithShadowMode(mode))
 	}
-
-	passwd.SetCacheOption(opts...)
-	group.SetCacheOption(opts...)
-	shadow.SetCacheOption(opts...)
 }

--- a/nss/passwd_c.go
+++ b/nss/passwd_c.go
@@ -30,7 +30,7 @@ func _nss_aad_getpwnam_r(name *C.char, pwd *C.struct_passwd, buf *C.char, buflen
 	logger.Debug(ctx, "_nss_aad_getpwnam_r called for %q", n)
 	n = user.NormalizeName(n)
 
-	p, err := passwd.NewByName(ctx, n)
+	p, err := passwd.NewByName(ctx, n, opts...)
 	if err != nil {
 		return errToCStatus(ctx, err, errnop)
 	}
@@ -47,7 +47,7 @@ func _nss_aad_getpwuid_r(uid C.uid_t, pwd *C.struct_passwd, buf *C.char, buflen 
 	defer logger.CloseLoggerFromContext(ctx)
 	logger.Debug(ctx, "_nss_aad_getpwuid_r called for %d", uid)
 
-	p, err := passwd.NewByUID(ctx, uint(uid))
+	p, err := passwd.NewByUID(ctx, uint(uid), opts...)
 	if err != nil {
 		return errToCStatus(ctx, err, errnop)
 	}
@@ -64,7 +64,7 @@ func _nss_aad_setpwent(stayopen C.int) C.nss_status {
 	defer logger.CloseLoggerFromContext(ctx)
 	logger.Debug(ctx, "_nss_aad_setpwent called")
 
-	err := passwd.StartEntryIteration(ctx)
+	err := passwd.StartEntryIteration(ctx, opts...)
 	if err != nil {
 		return errToCStatus(ctx, err, nil)
 	}

--- a/nss/shadow_c.go
+++ b/nss/shadow_c.go
@@ -28,7 +28,7 @@ func _nss_aad_getspnam_r(name *C.char, spwd *C.struct_spwd, buf *C.char, buflen 
 	logger.Debug(ctx, "_nss_aad_getspnam_r called for %q", n)
 	n = user.NormalizeName(n)
 
-	sp, err := shadow.NewByName(ctx, n)
+	sp, err := shadow.NewByName(ctx, n, opts...)
 	if err != nil {
 		return errToCStatus(ctx, err, errnop)
 	}
@@ -45,7 +45,7 @@ func _nss_aad_setspent() C.nss_status {
 	defer logger.CloseLoggerFromContext(ctx)
 	logger.Debug(ctx, "_nss_aad_setspent called")
 
-	err := shadow.StartEntryIteration(ctx)
+	err := shadow.StartEntryIteration(ctx, opts...)
 	if err != nil {
 		return errToCStatus(ctx, err, nil)
 	}


### PR DESCRIPTION
This removes the global variable testopts from the internal/nss package and refactor the packages to use cache.Options as optional arguments for some functions that relied upon testopts. Now the tests can be executed in parallel (and they are).
Also, the nss package now uses a global variable of his own rather than the passed testopts.