### PR TITLE
Fix small packaging oopsie

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -20,7 +20,6 @@ Description: Azure Active Directory Authentication
 Package: libpam-aad
 Architecture: any
 Built-Using: ${misc:Built-Using},
-Depends: ${shlibs:Depends},
 Depends: aad-common,
          ${shlibs:Depends},
          ${misc:Depends},
@@ -32,7 +31,6 @@ Description: ${source:Synopsis} module for PAM
 Package: libnss-aad
 Architecture: any
 Built-Using: ${misc:Built-Using},
-Depends: ${shlibs:Depends},
 Depends: aad-common,
          ${shlibs:Depends},
          ${misc:Depends},


### PR DESCRIPTION
When staging hunks for the i18n commits I may have mistakenly only staged the added lines without the removal lines, so we ended up with 2 sets of Depends which is bad by all accounts, as it renders the package unbuildable.