### PR TITLE
Fixed exit status handling

### DIFF
--- a/nss/common.c
+++ b/nss/common.c
@@ -16,7 +16,7 @@
 #define SCRIPTPATH "/usr/libexec/aad-auth"
 #endif
 
-gint run_aad_auth(const char *db, const char *name, const uid_t uid, enum nss_status *nss_exit_status, int *errnop, GPtrArray *entries)
+enum nss_status run_aad_auth(const char *db, const char *name, const uid_t uid, int *errnop, GPtrArray *entries)
 {
     gchar *stdout = NULL;
     gchar *stderr = NULL;
@@ -45,18 +45,24 @@ gint run_aad_auth(const char *db, const char *name, const uid_t uid, enum nss_st
     {
         *errnop = ENOENT;
         g_free(cmd);
-        return exit_status;
+        return NSS_STATUS_UNAVAIL;
     }
     g_free(cmd);
 
+    enum nss_status nss_exit_status;
     gchar **lines = g_strsplit(stdout, "\n", -1);
     for (gint i = 0; lines[i]; i++)
     {
+        if (!g_strcmp0(lines[i], ""))
+        {
+            continue;
+        }
+
         // first line is nss_exit_status:errno
         if (i == 0)
         {
             gchar **statuses = g_strsplit(lines[i], ":", 2);
-            *nss_exit_status = atoi(statuses[0]);
+            nss_exit_status = atoi(statuses[0]);
             *errnop = atoi(statuses[1]);
             g_strfreev(statuses);
             continue;
@@ -67,7 +73,14 @@ gint run_aad_auth(const char *db, const char *name, const uid_t uid, enum nss_st
     }
     g_strfreev(lines);
 
-    return 0;
+    // Handle badly handled wrapper (returning no element but success or empty list)
+    if (nss_exit_status == NSS_STATUS_SUCCESS && entries->len == 0)
+    {
+        *errnop = ENOENT;
+        return NSS_STATUS_UNAVAIL;
+    }
+
+    return nss_exit_status;
 }
 
 enum nss_status fetch_info(const char *db, const char *name, const uid_t uid, GPtrArray *all_entries, guint *all_entries_index, gchar **entry, int *errnop)
@@ -77,22 +90,20 @@ enum nss_status fetch_info(const char *db, const char *name, const uid_t uid, GP
     if (name != NULL || uid != 0)
     {
         GPtrArray *entries = g_ptr_array_new();
-        gint exit_status = run_aad_auth(db, name, uid, &nss_exit_status, errnop, entries);
-        if (exit_status != 0)
+        nss_exit_status = run_aad_auth(db, name, uid, errnop, entries);
+        if (nss_exit_status != NSS_STATUS_SUCCESS)
         {
-            *errnop = ENOENT;
-            return NSS_STATUS_UNAVAIL;
+            return nss_exit_status;
         }
         *entry = g_strdup((gchar *)g_ptr_array_index(entries, 0));
         g_ptr_array_free(entries, TRUE);
     }
     else if (all_entries->len == 0)
     {
-        gint exit_status = run_aad_auth(db, name, uid, &nss_exit_status, errnop, all_entries);
-        if (exit_status != 0)
+        nss_exit_status = run_aad_auth(db, name, uid, errnop, all_entries);
+        if (nss_exit_status != NSS_STATUS_SUCCESS)
         {
-            *errnop = ENOENT;
-            return NSS_STATUS_UNAVAIL;
+            return nss_exit_status;
         }
         *entry = g_strdup((gchar *)g_ptr_array_index(all_entries, *all_entries_index));
         (*all_entries_index)++;


### PR DESCRIPTION
External command and nss status were mixed up. We now only consider nss
exit status. Command line exit status is used to properly set errno and
nss exit status on error.

Co-authored-by: Didier Roche <didrocks@ubuntu.com>