### PR TITLE
Defering a call to clean the temp dir used in the tests.

### DIFF
--- a/pam/integration_test.go
+++ b/pam/integration_test.go
@@ -218,6 +218,7 @@ func TestMain(m *testing.M) {
 	if err != nil {
 		os.Exit(1)
 	}
+	defer cleanup()
 
 	libPath = filepath.Join(libDir, "pam_aad.so")
 	// #nosec:G204 - we control the command arguments in tests


### PR DESCRIPTION
The temp dir used to build the pam module in the integration tests was not being cleaned up after the tests were executed. Adding a defer call to fix this.