### PR TITLE
Fix output github action deprecation warning

### DIFF
--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -24,7 +24,7 @@ jobs:
       - name: Get version of golanci-lint to use
         id: cilint-version-fetch
         # This handles "require foo version" and "require (\nfoo version\n)"" formats
-        run: echo "{version}=$(grep golangci-lint tools/go.mod | rev | cut -f1 -d' ' | rev)" >> $GITHUB_OUTPUT
+        run: echo "version=$(grep golangci-lint tools/go.mod | rev | cut -f1 -d' ' | rev)" >> $GITHUB_OUTPUT
       - name: Code formatting, vet, static checker Security…
         uses: golangci/golangci-lint-action@v3
         with:


### PR DESCRIPTION
set-output is going to be deprecated as per
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/. Use the new syntax.