### PR TITLE
Adding Rust actions to GitHub CI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,3 +19,8 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -48,10 +48,10 @@ jobs:
           go build -ldflags='-s -w' -buildmode=c-shared -o pam_aad.so ./pam
 
           # Build NSS CLI executable
-          go build -o aad-auth ./nss/aad-auth
+          go build -o aad-auth ./nss-go/aad-auth
 
           # Build NSS C library
-          make -C nss/ libnss_aad.so.2
+          make -C nss-go/ libnss_aad.so.2
 
         if: ${{ always() }}
 

--- a/.github/workflows/rust-qa.yaml
+++ b/.github/workflows/rust-qa.yaml
@@ -1,0 +1,55 @@
+name: Rust QA
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - '*'
+  pull_request:
+
+jobs:
+  quality:
+    name: Code quality assessment
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+          components: rustfmt, clippy
+      - name: Build crate
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args:  --all-features
+      - name: Check code format with rustfmt
+        uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+      - name: Check code format with clippy
+        uses: actions-rs/clippy-check@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          args: --all-features
+
+  tests:
+    name: Tests and Coverage
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Run tests
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --all-features
+      - name: Get code coverage
+        id: rust-coverage
+        uses: actions-rs/tarpaulin@v0.1
+        with:
+          out-type: Json
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
This adds a couple of Rust actions to our CI. They are focused on assessing code quality, auditing dependencies security and running tests.

DEENG-559