### PR TITLE
Rust NSS: Temporarily disabling coverage

### DIFF
--- a/.github/workflows/rust-qa.yaml
+++ b/.github/workflows/rust-qa.yaml
@@ -44,12 +44,15 @@ jobs:
         with:
           command: test
           args: --all-features
-      - name: Get code coverage
-        id: rust-coverage
-        uses: actions-rs/tarpaulin@v0.1
-        with:
-          out-type: Json
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+      # TODO: Right now, tarpaulin is having some problems that we'll have to debug in the future.
+      #       Since codecov does not support private repositories, we should just keep checking the
+      #       coverage locally and fix this action before opening the repository again.
+      # - name: Get code coverage
+      #   id: rust-coverage
+      #   uses: actions-rs/tarpaulin@v0.1
+      #   with:
+      #     out-type: Json
+      # - name: Upload coverage to Codecov
+      #   uses: codecov/codecov-action@v3
+      #   with:
+      #     token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Right now, the coverage action is failing due to some issue with the used extension (tarpaulin). Ideally, we should use grcov, which is supported by Mozilla but it has some problems with the way we get the thread name in order to figure out the testpath for the golden files. 
Since `codecov` does not work with private repositories, we should keep checking the code coverage locally and re-enable the coverage action once we decide to open the repository again.
I thought about leaving the action as is, but having the checks always failing is leading to some false sense that it's always the coverage action failing, which could result in some clippy warnings or test failures being wrongfully ignored.