### PR TITLE
Changing auto update action targets to main

### DIFF
--- a/.github/workflows/auto-updates.yaml
+++ b/.github/workflows/auto-updates.yaml
@@ -1,11 +1,11 @@
 name: Update translations in main branch automatically
 on:
   push:
-    # TODO: UNCOMMENT WHEN MERGING RUST-NSS TO MAIN
-    # branches:
-    #   - main
+    branches:
+      - main
     paths-ignore:
       - po/*
+      - debian/control
 
 jobs:
   update-po:
@@ -66,6 +66,8 @@ jobs:
           DEBIAN_FRONTEND=noninteractive apt update
           DEBIAN_FRONTEND=noninteractive apt install -y cargo dh-cargo git
       - uses: actions/checkout@v3
+        with:
+          ref: main
       - name: Vendoring the dependencies
         run: |
           cargo vendor vendor_rust/
@@ -96,9 +98,8 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Push branch
         if: ${{ env.modified == 'true' }}
-        # TODO: FIX TARGET WHEN MERGING TO MAIN
         run: |
-          git push origin auto-update-rust-vendored-sources:rust-nss
+          git push origin auto-update-rust-vendored-sources:main
 
   update-fake-checksum-file:
     name: 'Update the fake checksum file at d/cargo-checksum.json'
@@ -110,6 +111,8 @@ jobs:
           sudo DEBIAN_FRONTEND=noninteractive apt update
           sudo DEBIAN_FRONTEND=noninteractive apt install -y git nodejs
       - uses: actions/checkout@v3
+        with:
+          ref: main
       - name: 'Install GitHub script dependencies'
         run: npm install -D toml @types/node
       - name: 'Update the checksum file'
@@ -159,6 +162,5 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Push branch
         if: ${{ steps.update-checksum.outputs.result == 'true' }}
-        # TODO: FIX TARGET WHEN MERGING TO MAIN
         run: |
-          git push origin auto-update-rust-checksum:rust-nss
+          git push origin auto-update-rust-checksum:main


### PR DESCRIPTION
Now that Rust NSS was merged into main, we need to change the autoupdate action to make it target the right branch.