### PR TITLE
Fixing dubious ownership fatal error

### DIFF
--- a/.github/workflows/auto-updates.yaml
+++ b/.github/workflows/auto-updates.yaml
@@ -85,7 +85,11 @@ jobs:
 
           echo "modified=true" >> $GITHUB_ENV
         shell: bash
-
+      # Since we run this job in a container, we need to manually add the safe directory due to some
+      # issues between actions/checkout and actions/runner, which seem to be triggered by multiple
+      # causes (e.g. https://github.com/actions/runner-images/issues/6775, https://github.com/actions/checkout/issues/1048#issuecomment-1356485556).
+      - name: work around permission issue with git vulnerability (we are local here). TO REMOVE
+        run: git config --global --add safe.directory /__w/aad-auth/aad-auth
       - name: Create Pull Request
         if: ${{ env.modified == 'true' }}
         # V5 Beta needed because of https://github.com/peter-evans/create-pull-request/issues/1170


### PR DESCRIPTION
In order to use the dh-cargo-vendored-sources script, we need to use ubuntu kinetic or above (it's not available for jammy yet). This creates a mismatch between git versions which then creates a miscommunication between the safe directory configuration, so we need this hack to avoid failing the action.