### PR TITLE
Moving log init call to a constructor in lib.rs

### DIFF
--- a/nss/src/group/mod.rs
+++ b/nss/src/group/mod.rs
@@ -5,7 +5,7 @@ use libnss::interop::Response;
 
 use crate::{
     cache::{CacheError, Group as CacheGroup},
-    debug, init_logger,
+    debug,
 };
 
 pub struct AADGroup;
@@ -13,7 +13,6 @@ pub struct AADGroup;
 impl GroupHooks for AADGroup {
     /// get_all_entries retrieves all group entries from the cache database.
     fn get_all_entries() -> Response<Vec<Group>> {
-        init_logger();
         debug!("get_all_entries for group");
 
         let c = match super::new_cache() {
@@ -27,7 +26,6 @@ impl GroupHooks for AADGroup {
 
     /// get_entry_by_gid retrieves a group entry by gid.
     fn get_entry_by_gid(gid: gid_t) -> Response<Group> {
-        init_logger();
         debug!("get_entry_by_gid for group with gid: {gid}");
 
         let c = match super::new_cache() {
@@ -41,7 +39,6 @@ impl GroupHooks for AADGroup {
 
     /// get_entry_by_name retrieves a group entry by name.
     fn get_entry_by_name(name: String) -> Response<Group> {
-        init_logger();
         debug!("get_entry_by_gid for group with name: {name}");
 
         let c = match super::new_cache() {

--- a/nss/src/lib.rs
+++ b/nss/src/lib.rs
@@ -1,9 +1,9 @@
 #[cfg(feature = "integration-tests")]
 use cache::CacheDBBuilder;
 #[cfg(feature = "integration-tests")]
-use ctor::ctor;
-#[cfg(feature = "integration-tests")]
 use std::env;
+
+use ctor::ctor;
 
 #[macro_use]
 extern crate lazy_static; // used by libnss_*_hooks macros
@@ -25,7 +25,6 @@ mod cache;
 use crate::cache::{CacheDB, CacheError};
 
 mod logs;
-use logs::init_logger;
 
 // cache_result_to_nss_status converts our internal CacheError to a nss-compatible Response.
 fn cache_result_to_nss_status<T>(r: Result<T, CacheError>) -> Response<T> {
@@ -70,6 +69,13 @@ fn new_cache() -> Result<CacheDB, CacheError> {
     }
 
     c.build()
+}
+
+#[ctor]
+/// init_logger is a constructor that ensures the logger object initialization only happens once per
+/// library invocation in order to avoid races to the log file.
+fn init_logger() {
+    logs::init_logger();
 }
 
 /// override_cache_options parses the NSS_AAD env variables and overrides the cache default options

--- a/nss/src/passwd/mod.rs
+++ b/nss/src/passwd/mod.rs
@@ -5,7 +5,7 @@ use libnss::passwd::{Passwd, PasswdHooks};
 
 use crate::{
     cache::{CacheError, Passwd as CachePasswd},
-    debug, init_logger,
+    debug,
 };
 
 pub struct AADPasswd;
@@ -13,7 +13,6 @@ pub struct AADPasswd;
 impl PasswdHooks for AADPasswd {
     /// get_all_entries retrieves all the password entries from the cache database.
     fn get_all_entries() -> Response<Vec<Passwd>> {
-        init_logger();
         debug!("get_all_entries for passwd");
 
         let c = match super::new_cache() {
@@ -27,7 +26,6 @@ impl PasswdHooks for AADPasswd {
 
     /// get_entry_by_uid retrieves a password entry by user id.
     fn get_entry_by_uid(uid: uid_t) -> Response<Passwd> {
-        init_logger();
         debug!("get_entry_by_uid for passwd for uid: {uid}");
 
         let c = match super::new_cache() {
@@ -41,7 +39,6 @@ impl PasswdHooks for AADPasswd {
 
     /// get_entry_by_name retrieves a password entry by user name.
     fn get_entry_by_name(name: String) -> Response<Passwd> {
-        init_logger();
         debug!("get_entry_by_name for passwd for name: {name}");
 
         let c = match super::new_cache() {

--- a/nss/src/shadow/mod.rs
+++ b/nss/src/shadow/mod.rs
@@ -3,7 +3,7 @@ use libnss::shadow::{Shadow, ShadowHooks};
 
 use crate::{
     cache::{CacheError, Shadow as CacheShadow},
-    debug, init_logger,
+    debug,
 };
 
 pub struct AADShadow;
@@ -11,7 +11,6 @@ pub struct AADShadow;
 impl ShadowHooks for AADShadow {
     /// get_all_entries retrieves all the shadow entries from the cache database.
     fn get_all_entries() -> Response<Vec<Shadow>> {
-        init_logger();
         debug!("get_all_entries for shadow");
 
         let c = match super::new_cache() {
@@ -25,7 +24,6 @@ impl ShadowHooks for AADShadow {
 
     /// get_entry_by_name retrieves a shadow entry by user name.
     fn get_entry_by_name(name: String) -> Response<Shadow> {
-        init_logger();
         debug!("get_entry_by_name for shadow for name: {name}");
 
         let c = match super::new_cache() {


### PR DESCRIPTION
The logger was being initialized in each hook call, which could result in races when running the tests (which run in parallel by default) or when executing multiple NSS calls in sequence.

Now, after creating the constructor and removing the initialization from each hook function, this issue should be prevented since the logger will only be initialized when the library is being initialized.