### PR TITLE
Add coverage to NSS integration tests

### DIFF
--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -60,13 +60,26 @@ jobs:
       - name: Install dependencies
         run: |
           sudo DEBIAN_FRONTEND=noninteractive apt update
-          sudo DEBIAN_FRONTEND=noninteractive apt install -y gcc libpam-dev curl gettext
+          sudo DEBIAN_FRONTEND=noninteractive apt install -y gcc libpam-dev curl gettext libsqlite3-dev
+      - name: Install cargo (nightly to get coverage)
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          override: true
+          components: llvm-tools-preview
+      - name: Install grcov
+        run: cargo install grcov
       - name: Run tests
-        run: go test -coverpkg=./... -coverprofile=/tmp/coverage.out -covermode=count ./...
+        run: |
+          set -eu
+          go test -coverpkg=./... -coverprofile=/tmp/coverage.out -covermode=set ./...
+
+          # Filter out test utilities
+          grep -hv -e "testutils" /tmp/coverage.out > /tmp/coverage.filtered.out
       - name: Run tests (with race detector)
         run: go test -race ./...
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          file: /tmp/coverage.out
+          file: /tmp/coverage.filtered.out

--- a/internal/testutils/coverage.go
+++ b/internal/testutils/coverage.go
@@ -1,0 +1,158 @@
+package testutils
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/exp/slices"
+)
+
+var (
+	goMainCoverProfile     string
+	goMainCoverProfileOnce sync.Once
+
+	coveragesToMerge   []string
+	coveragesToMergeMu sync.Mutex
+)
+
+// TrackTestCoverage starts tracking coverage in a dedicated file based on current test name.
+// This file will be merged to the current coverage main file.
+// It’s up to the test use the returned path to file golang-compatible cover format content.
+// To collect all coverages, then MergeCoverages() should be called after m.Run().
+// If coverage is not enabled, nothing is done.
+func TrackTestCoverage(t *testing.T) (testCoverFile string) {
+	t.Helper()
+
+	goMainCoverProfileOnce.Do(func() {
+		for _, arg := range os.Args {
+			if !strings.HasPrefix(arg, "-test.coverprofile=") {
+				continue
+			}
+			goMainCoverProfile = strings.TrimPrefix(arg, "-test.coverprofile=")
+		}
+	})
+
+	if goMainCoverProfile == "" {
+		return ""
+	}
+
+	coverAbsPath, err := filepath.Abs(goMainCoverProfile)
+	require.NoError(t, err, "Setup: can't transform go cover profile to absolute path")
+
+	testCoverFile = fmt.Sprintf("%s.%s", coverAbsPath, strings.ReplaceAll(
+		strings.ReplaceAll(t.Name(), "/", "_"),
+		"\\", "_"))
+
+	coveragesToMergeMu.Lock()
+	defer coveragesToMergeMu.Unlock()
+	if slices.Contains(coveragesToMerge, testCoverFile) {
+		t.Fatalf("Trying to adding a second time %q to the list of file to cover. This will create some overwrite and thus, should be only called once", testCoverFile)
+	}
+	coveragesToMerge = append(coveragesToMerge, testCoverFile)
+
+	return testCoverFile
+}
+
+// MergeCoverages append all coverage files marked for merging to main Go Cover Profile.
+// This has to be called after m.Run() in TestMain so that the main go cover profile is created.
+// This has no action if profiling is not enabled.
+func MergeCoverages() {
+	coveragesToMergeMu.Lock()
+	defer coveragesToMergeMu.Unlock()
+	for _, cov := range coveragesToMerge {
+		fmt.Printf("COVERAGE: %s", cov)
+		if err := appendToFile(cov, goMainCoverProfile); err != nil {
+			log.Fatalf("Teardown: can’t inject coverage into the golang one: %v", err)
+		}
+	}
+	coveragesToMerge = nil
+}
+
+// WantCoverage returns true if coverage was requested in test.
+func WantCoverage() bool {
+	for _, arg := range os.Args {
+		if !strings.HasPrefix(arg, "-test.coverprofile=") {
+			continue
+		}
+		return true
+	}
+	return false
+}
+
+// appendToFile appends src to the dst coverprofile file at the end.
+func appendToFile(src, dst string) error {
+	f, err := os.Open(filepath.Clean(src))
+	if err != nil {
+		return fmt.Errorf("can't open coverage file: %w", err)
+	}
+	defer f.Close()
+
+	d, err := os.OpenFile(dst, os.O_APPEND|os.O_WRONLY, 0600)
+	if err != nil {
+		return fmt.Errorf("can't open golang cover profile file: %w", err)
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		if strings.HasPrefix(scanner.Text(), "mode: ") {
+			continue
+		}
+		if _, err := d.Write([]byte(scanner.Text() + "\n")); err != nil {
+			return fmt.Errorf("can't write to golang cover profile file: %w", err)
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return fmt.Errorf("error while scanning golang cover profile file: %w", err)
+	}
+	return nil
+}
+
+// fqdnToPath allows to return the fqdn path for this file relative to go.mod.
+func fqdnToPath(t *testing.T, path string) string {
+	t.Helper()
+
+	srcPath, err := filepath.Abs(path)
+	require.NoError(t, err, "Setup: can't calculate absolute path")
+
+	d := srcPath
+	for d != "/" {
+		f, err := os.Open(filepath.Clean(filepath.Join(d, "go.mod")))
+		if err != nil {
+			d = filepath.Dir(d)
+			continue
+		}
+		defer func() { assert.NoError(t, f.Close(), "Setup: can’t close go.mod") }()
+
+		r := bufio.NewReader(f)
+		l, err := r.ReadString('\n')
+		require.NoError(t, err, "can't read go.mod first line")
+		if !strings.HasPrefix(l, "module ") {
+			t.Fatal(`Setup: failed to find "module" line in go.mod`)
+		}
+
+		prefix := strings.TrimSpace(strings.TrimPrefix(l, "module "))
+		relpath := strings.TrimPrefix(srcPath, d)
+		return filepath.Join(prefix, relpath)
+	}
+
+	t.Fatal("failed to find go.mod")
+	return ""
+}
+
+// writeGoCoverageLine writes given line in go coverage format to w.
+func writeGoCoverageLine(t *testing.T, w io.Writer, file string, lineNum, lineLength int, covered string) {
+	t.Helper()
+
+	_, err := w.Write([]byte(fmt.Sprintf("%s:%d.1,%d.%d 1 %s\n", file, lineNum, lineNum, lineLength, covered)))
+	require.NoErrorf(t, err, "Teardown: can't write a write to golang compatible cover file : %v", err)
+}

--- a/internal/testutils/rust.go
+++ b/internal/testutils/rust.go
@@ -1,0 +1,199 @@
+package testutils
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// MarkRustFilesForTestCache marks all rust files and related content to be in the Go test caching infra.
+func MarkRustFilesForTestCache(t *testing.T, rustDir string) {
+	t.Helper()
+
+	markForTestCache(t, []string{
+		filepath.Join(rustDir, "src"),
+		filepath.Join(rustDir, "testdata"),
+		filepath.Join(rustDir, "Cargo.toml"),
+		filepath.Join(rustDir, "Cargo.lock"),
+	})
+}
+
+// CanRunRustTests returns if we can run rust tests via cargo on this machine.
+// It checks for code coverage report if supported.
+func CanRunRustTests(coverageWanted bool) (err error) {
+	d, err := exec.Command("cargo", "--version").CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("cargo can't be executed: %w", err)
+	}
+
+	if !coverageWanted {
+		return nil
+	}
+
+	// Only nightly has code coverage enabled
+	supportCoverage := strings.Contains(string(d), "nightly")
+	if !supportCoverage {
+		return errors.New("coverage is requested but your cargo/rust version does not support it (needs nightly)")
+	}
+
+	// We need grcov for coverage report. However, even --help or --version creates a profile file in current directory.
+	// Doing that in a temporary directory we clean then.
+	tmp, err := os.MkdirTemp("", "grcov-test-*")
+	if err != nil {
+		return fmt.Errorf("can't create temporary directory to test grcov: %w", err)
+	}
+	defer os.RemoveAll(tmp)
+
+	cmd := exec.Command("grcov", "--version")
+	cmd.Env = append(os.Environ(), "LLVM_PROFILE_FILE="+tmp)
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("grcov is needed for coverage report and can't be executed: %w", err)
+	}
+
+	return nil
+}
+
+// TrackRustCoverage returns environment variables and target directory so that following commands
+// runs with code coverage enabled.
+// Note that for developping purposes and avoiding keeping building the rust program dependencies,
+// TEST_RUST_TARGET environment variable can be set to keep iterative build artifacts.
+// This then allow coverage to run in parallel, as each subprocess will have its own environment.
+// You will need to call MergeCoverages() after m.Run().
+// If code coverage is not enabled, it still returns an empty slice, but the target can be used.
+func TrackRustCoverage(t *testing.T, src string) (env []string, target string) {
+	t.Helper()
+
+	target = os.Getenv("TEST_RUST_TARGET")
+	if target == "" {
+		target = t.TempDir()
+	}
+
+	testGoCoverage := TrackTestCoverage(t)
+	if testGoCoverage == "" {
+		return []string{}, target
+	}
+
+	coverDir := filepath.Dir(testGoCoverage)
+
+	t.Cleanup(func() {
+		rustJSONCoverage := testGoCoverage + ".json"
+		// nolint:gosec // G204 we define what we cover ourself
+		cmd := exec.Command("grcov", coverDir,
+			"--binary-path", filepath.Join(target, "debug"),
+			"--source-dir", src,
+			"--ignore-not-existing",
+			"--ignore=**/build.rs",
+			"--ignore=**/*_tests.rs",
+			"--ignore=**/testutils/**",
+			"-t", "covdir",
+			"-o", rustJSONCoverage)
+		cmd.Env = append(os.Environ(), "LLVM_PROFILE_FILE="+coverDir)
+
+		out, err := cmd.CombinedOutput()
+		require.NoError(t, err, "Teardown: could not convert coverage to json format: %s", out)
+
+		// Load our converted JSON profile.
+		var results map[string]interface{}
+		d, err := os.ReadFile(rustJSONCoverage)
+		require.NoError(t, err, "Teardown: can't read our json coverage file")
+		err = json.Unmarshal(d, &results)
+		require.NoError(t, err, "Teardown: decode our json coverage file")
+
+		// This is the destination file for rust coverage in go format.
+		outF, err := os.Create(testGoCoverage)
+		require.NoErrorf(t, err, "Teardown: failed opening output golang compatible cover file: %s", err)
+		defer func() { assert.NoError(t, outF.Close(), "Teardown: can’t close golang compatible cover file") }()
+
+		// Scan our results to write to it.
+		scan(t, results, fqdnToPath(t, src), outF)
+	})
+
+	return []string{
+		"RUSTFLAGS=-Cinstrument-coverage",
+		"LLVM_PROFILE_FILE=" + filepath.Join(coverDir, "rust-%p-%m.profraw"),
+	}, target
+}
+
+// scan iterates over children files and folders elements recursively.
+func scan(t *testing.T, results map[string]interface{}, p string, w io.Writer) {
+	t.Helper()
+
+	// Scan a file.
+	r := results["coverage"]
+	if r != nil {
+		res, ok := r.([]interface{})
+		if !ok {
+			t.Fatalf("%v for coverage report is not a slice of floats in interface", r)
+		}
+		convertRustFileResult(t, res, p, w)
+		return
+	}
+
+	// Scan children files or folders.
+	r = results["children"]
+	if r != nil {
+		res, ok := r.(map[string]interface{})
+		if !ok {
+			t.Fatalf("children %v is not a map of data", r)
+		}
+		// Iterate over files or dir.
+		for elem, subResults := range res {
+			// We are not interesting in other code than ours
+			if elem == "/" {
+				continue
+			}
+
+			res, ok := subResults.(map[string]interface{})
+			// Skip summary coverage-related data
+			if !ok {
+				continue
+			}
+			scan(t, res, filepath.Join(p, elem), w)
+		}
+	}
+}
+
+// convertRustFileResult converts rust-formatted coverage content to go one and writes it to w.
+func convertRustFileResult(t *testing.T, results []interface{}, p string, w io.Writer) {
+	t.Helper()
+
+	for l, r := range results {
+		v, ok := r.(float64)
+		if !ok {
+			t.Fatalf("%v for coverage report is not a float", r)
+		}
+		var covered string
+		switch v {
+		case -1:
+			continue
+		case 0:
+			covered = "0"
+		default:
+			// We are in mode set, so don’t count the number of runs
+			covered = "1"
+		}
+		// We are doing line coverage and we don’t have the source line handy. Set it to 9999 then.
+		writeGoCoverageLine(t, w, p, l+1, 9999, covered)
+	}
+}
+
+// markForTestCache list all root directories/files so that they are marked in the test cache.
+func markForTestCache(t *testing.T, roots []string) {
+	t.Helper()
+
+	for _, root := range roots {
+		err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+			return nil
+		})
+		require.NoError(t, err, "Setup: Error when listing input files for caching handling")
+	}
+}

--- a/nss/coverage.go
+++ b/nss/coverage.go
@@ -1,0 +1,2 @@
+// Package coveragenss file is only here so that it’s recognized as a go package when computing coverage
+package coveragenss

--- a/nss/src/cache/coverage.go
+++ b/nss/src/cache/coverage.go
@@ -1,0 +1,2 @@
+// Package coveragecache file is only here so that it’s recognized as a go package when computing coverage
+package coveragecache

--- a/nss/src/coverage.go
+++ b/nss/src/coverage.go
@@ -1,0 +1,4 @@
+// Package coveragesrc file is only here so that it’s recognized as a go package when computing coverage
+package coveragesrc
+
+import "C"

--- a/nss/src/group/coverage.go
+++ b/nss/src/group/coverage.go
@@ -1,0 +1,2 @@
+// Package coveragegroup file is only here so that it’s recognized as a go package when computing coverage
+package coveragegroup

--- a/nss/src/logs/coverage.go
+++ b/nss/src/logs/coverage.go
@@ -1,0 +1,2 @@
+// Package coveragelogs file is only here so that it’s recognized as a go package when computing coverage
+package coveragelogs

--- a/nss/src/passwd/coverage.go
+++ b/nss/src/passwd/coverage.go
@@ -1,0 +1,2 @@
+// Package coveragepasswd file is only here so that it’s recognized as a go package when computing coverage
+package coveragepasswd

--- a/nss/src/shadow/coverage.go
+++ b/nss/src/shadow/coverage.go
@@ -1,0 +1,2 @@
+// Package coverageshadow file is only here so that it’s recognized as a go package when computing coverage
+package coverageshadow

--- a/nss/src/testutils/coverage.go
+++ b/nss/src/testutils/coverage.go
@@ -1,2 +1,0 @@
-// Package coveragetestutils file is only here so that it’s recognized as a go package when computing coverage
-package coveragetestutils

--- a/nss/src/testutils/coverage.go
+++ b/nss/src/testutils/coverage.go
@@ -1,0 +1,2 @@
+// Package coveragetestutils file is only here so that it’s recognized as a go package when computing coverage
+package coveragetestutils


### PR DESCRIPTION
Reusing the tools created in adsys to track Rust coverage when running Go tests and adapting the integration tests to the new build pattern.

DEENG-613