### PR TITLE
Replacing backend used by `rustix` crate

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -58,6 +58,7 @@ override_dh_auto_configure:
 	[ ! -e $(DH_CARGO_VENDORED_SOURCES) ] || $(DH_CARGO_VENDORED_SOURCES)
 	DEB_HOST_GNU_TYPE=$(DEB_HOST_GNU_TYPE) DEB_HOST_RUST_TYPE=$(DEB_HOST_RUST_TYPE) \
 		CARGO_HOME=$(CURDIR)/debian/cargo_home DEB_CARGO_CRATE=nss_aad_$(shell dpkg-parsechangelog --show-field Version) \
+		RUSTFLAGS="--cfg=rustix_use_libc" \
 		$(CARGO) prepare-debian $(CARGO_VENDOR_DIR)
 
 	# By default, dh-cargo only replaces the crates-io source, which means we have to replace the git source manually


### PR DESCRIPTION
The rustix crate has the option of two backends to use: libc and linux_raw.
The linux_raw backend is shipped with .a files, which are the outlines that are statically linked at build time. Those files get removed when building the package and then "Houston, we have a problem". Usually this doesn't matter since the default way rustix builds itself is using asm, but this feature is experimental for ppc64el and MIPS architectures.
To fix this problem, we need to switch to using the libc backend, which is composed of only source files and, therefore, represents no issue to us.

DEENG-616