### PR TITLE
Remove explicit cache option from setup-go action

### DIFF
--- a/.github/workflows/auto-updates.yaml
+++ b/.github/workflows/auto-updates.yaml
@@ -25,7 +25,6 @@ jobs:
       - uses: actions/setup-go@v4
         with:
           go-version-file: go.mod
-          cache: true
       # Update po if needed
       - name: Check po files
         id: checkpo

--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -20,7 +20,6 @@ jobs:
       - uses: actions/setup-go@v4
         with:
           go-version-file: go.mod
-          cache: true
       - name: Get version of golanci-lint to use
         id: cilint-version-fetch
         # This handles "require foo version" and "require (\nfoo version\n)"" formats

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -16,7 +16,6 @@ jobs:
         - uses: actions/setup-go@v4
           with:
             go-version-file: go.mod
-            cache: true
         - name: Install dependencies
           run: |
             set -eu


### PR DESCRIPTION
This is now on by default in version 4, according to https://github.com/actions/setup-go/releases