### PR TITLE
Switching libnss dependency source branch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -264,7 +264,7 @@ checksum = "99227334921fae1a979cf0bfdfcc6b3e5ce376ef57e16fb6fb3ea2ed6095f80c"
 [[package]]
 name = "libnss"
 version = "0.4.0"
-source = "git+https://github.com/ubuntu/libnss-rs/?branch=fixing-struct-types#02e0fa4ad1beb62fd450bb34075125c11dbd44a6"
+source = "git+https://github.com/ubuntu/libnss-rs/?branch=misc-fixes#84599b3fc81def21ea9c8372d626d6d129a8e744"
 dependencies = [
  "lazy_static",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,4 +14,4 @@ exclude = ["vendor_rust/"]
 lto = "thin"
 
 [patch.crates-io]
-libnss = { git = "https://github.com/ubuntu/libnss-rs/", branch = "fixing-struct-types" }
+libnss = { git = "https://github.com/ubuntu/libnss-rs/", branch = "misc-fixes" }


### PR DESCRIPTION
Now we have 2 fixes to submit to upstream. Since they have to be on different PRs, we had to create a branch that would glob all commits for us to use in aad-auth.

Closes #179 / DEENG-651