### PR TITLE
Restore add-safe-directory-fix

### DIFF
--- a/.github/workflows/auto-updates.yaml
+++ b/.github/workflows/auto-updates.yaml
@@ -90,6 +90,11 @@ jobs:
 
           echo "modified=true" >> $GITHUB_ENV
         shell: bash
+      # Since we run this job in a container, we need to manually add the safe directory due to some
+      # issues between actions/checkout and actions/runner, which seem to be triggered by multiple
+      # causes (e.g. https://github.com/actions/runner-images/issues/6775, https://github.com/actions/checkout/issues/1048#issuecomment-1356485556).
+      - name: work around permission issue with git vulnerability (we are local here). TO REMOVE
+        run: git config --global --add safe.directory /__w/aad-auth/aad-auth
       - name: Create Pull Request
         if: ${{ env.modified == 'true' }}
         uses: peter-evans/create-pull-request@v5


### PR DESCRIPTION
When bumping the create-pull-request action to v5, we thought the manual run of the git command to add the safe directory wouldn't be necessary anymore, but sadly it still is due to the container runner used in the action.