### PR TITLE
Switch the cargo config patch to the right branch

### DIFF
--- a/debian/cargo-config-patch
+++ b/debian/cargo-config-patch
@@ -1,4 +1,4 @@
 [source."https://github.com/ubuntu/libnss-rs/"]
 git = "https://github.com/ubuntu/libnss-rs/"
-branch = "fixing-struct-types"
+branch = "misc-fixes"
 replace-with = "dh-cargo-registry"


### PR DESCRIPTION
In #184, we changed the branch used as the source for the libnss crate. Sadly, we forgot to also update the config.toml patch that replaced that source when building the package, which ended up breaking the build.

This PR fixes the target to be the right branch.