### PR TITLE
Shadow mode eval now considers effective ids

### DIFF
--- a/internal/cache/cachedb.go
+++ b/internal/cache/cachedb.go
@@ -113,11 +113,12 @@ func initDB(ctx context.Context, cacheDir string, rootUID, rootGID, shadowGID, f
 	// Attach shadow if our user has access to the file (even read-only)
 	shadowMode = forceShadowMode
 	if forceShadowMode == -1 {
-		shadowMode = 0
-		if unix.Access(shadowPath, unix.W_OK) == nil {
-			shadowMode = shadowRWMode
-		} else if unix.Access(shadowPath, unix.R_OK) == nil {
+		shadowMode = shadowNotAvailableMode
+		if unix.Faccessat(unix.AT_FDCWD, shadowPath, unix.R_OK, unix.AT_EACCESS) == nil {
 			shadowMode = shadowROMode
+		}
+		if unix.Faccessat(unix.AT_FDCWD, shadowPath, unix.W_OK, unix.AT_EACCESS) == nil {
+			shadowMode = shadowRWMode
 		}
 	}
 	if shadowMode > shadowNotAvailableMode {


### PR DESCRIPTION
In order to determine the shadow mode of the cache, we were using `unix.Access()`, which considers only the real uid and gid of the current process. This was causing `sudo` calls to fail, since they only change the `effective` uid of the current process.

Replacing `unix.Access()` by `unix.Faccessat()` allows us to consider the `effective` uid of the caller instead, allowing `sudo` calls to work if the user is in the `sudo` group or in the `/etc/sudoers` file.

Closes #197 
DEENG-664