### PR TITLE
Add default scopes for getting AuthToken from MSAL

### DIFF
--- a/internal/aad/aad.go
+++ b/internal/aad/aad.go
@@ -61,7 +61,7 @@ func (auth AAD) Authenticate(ctx context.Context, cfg config.AAD, username, pass
 	}
 
 	// Authentify the user
-	_, errAcquireToken = app.AcquireTokenByUsernamePassword(ctx, nil, username, password)
+	_, errAcquireToken = app.AcquireTokenByUsernamePassword(ctx, []string{"openid", "profile"}, username, password)
 
 	var callErr msalErrors.CallErr
 	if errors.As(errAcquireToken, &callErr) {


### PR DESCRIPTION
Due to policy changes in MSAL 1.0, scopes need to be explicitly specified. Following initial discussion in issue #256, this is an attempt to fix the issue by explicitly providing `openid` and `profile` scopes.

Closes #256