### PR TITLE
Add resolver definition to root manifest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -337,6 +337,7 @@ dependencies = [
  "libnss",
  "log",
  "paste 1.0.12",
+ "proc-macro2",
  "rusqlite",
  "serde",
  "serde_yaml",
@@ -426,9 +427,9 @@ checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.52"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d0e1ae9e836cc3beddd63db0df682593d7e2d3d891ae8c9083d2113e1744224"
+checksum = "7b368fba921b0dce7e60f5e04ec15e565b3303972b42bcfde1d0713b881959eb"
 dependencies = [
  "unicode-ident",
 ]
@@ -508,7 +509,7 @@ checksum = "d9735b638ccc51c28bf6914d90a2e9725b377144fc612c49a611fddd1b631d68"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.3",
+ "syn 2.0.16",
 ]
 
 [[package]]
@@ -574,9 +575,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.3"
+version = "2.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8234ae35e70582bfa0f1fedffa6daa248e41dd045310b19800c4a36382c8f60"
+checksum = "a6f671d4b5ffdb8eadec19c0ae67fe2639df8684bd7bc4b83d986b8db549cf01"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = ["nss"]
 exclude = ["vendor_rust/"]
+resolver = "2"
 
 [profile.release]
 # According to https://github.com/rust-lang/rust/issues/66118, enabling LTO results in some problems

--- a/nss/Cargo.toml
+++ b/nss/Cargo.toml
@@ -27,6 +27,7 @@ faccess = "0.2.4"
 simple_logger = { version = "4.1.0", default-features = false, features = [
     "stderr",
 ] }
+proc-macro2 = "1.0.63"
 
 [dev-dependencies]
 goldenfile = "^1.4"


### PR DESCRIPTION
Our CI started failing when building the `proc-macro2` crate and cargo gave us some notes:
```text
Setup: could not build Rust NSS library: warning: some crates are on edition 2021 which defaults to `resolver = "2"`, but virtual workspaces default to `resolver = "1"`
note: to keep the current resolver, specify `workspace.resolver = "1"` in the workspace root's manifest
note: to use the edition 2021 resolver, specify
`workspace.resolver = "2"` in the workspace root's manifest
```

So we should lock the resolver to version "2" directly on the root Cargo manifest and turn the `proc-macro2` transitive dependency into an actual one, so we can better control its version.