### PR TITLE
Normalize username used in getXXbyname NSS queries

### DIFF
--- a/nss/integration-tests/integration_test.go
+++ b/nss/integration-tests/integration_test.go
@@ -36,9 +36,12 @@ func TestIntegration(t *testing.T) {
 		wantErr bool
 	}{
 		// List entry by name
-		"list entry from passwd by name": {db: "passwd", key: "myuser@domain.com"},
-		"list entry from group by name":  {db: "group", key: "myuser@domain.com"},
-		"list entry from shadow by name": {db: "shadow", key: "myuser@domain.com"},
+		"list entry from passwd by name":               {db: "passwd", key: "myuser@domain.com"},
+		"list entry from passwd with capitalized name": {db: "passwd", key: "MyUser@Domain.Com"},
+		"list entry from group by name":                {db: "group", key: "myuser@domain.com"},
+		"list entry from group with capitalized name":  {db: "group", key: "MyUser@Domain.Com"},
+		"list entry from shadow by name":               {db: "shadow", key: "myuser@domain.com"},
+		"list entry from shadow with capitalized name": {db: "shadow", key: "MyUser@Domain.Com"},
 
 		// List entry by UID/GID
 		"list entry from passwd by uid":               {db: "passwd", key: "165119649"},

--- a/nss/integration-tests/testdata/golden/TestIntegration/list_entry_from_group_with_capitalized_name
+++ b/nss/integration-tests/testdata/golden/TestIntegration/list_entry_from_group_with_capitalized_name
@@ -1,0 +1,2 @@
+|
+    myuser@domain.com:x:1929326240:myuser@domain.com

--- a/nss/integration-tests/testdata/golden/TestIntegration/list_entry_from_passwd_with_capitalized_name
+++ b/nss/integration-tests/testdata/golden/TestIntegration/list_entry_from_passwd_with_capitalized_name
@@ -1,0 +1,2 @@
+|
+    myuser@domain.com:x:1929326240:1929326240:My User:/home/myuser@domain.com:/bin/bash

--- a/nss/integration-tests/testdata/golden/TestIntegration/list_entry_from_shadow_with_capitalized_name
+++ b/nss/integration-tests/testdata/golden/TestIntegration/list_entry_from_shadow_with_capitalized_name
@@ -1,0 +1,2 @@
+|
+    myuser@domain.com:*:::::::

--- a/nss/src/cache/mod.rs
+++ b/nss/src/cache/mod.rs
@@ -704,4 +704,9 @@ impl CacheDB {
         tx.commit()?;
         Ok(())
     }
+
+    /// normalize_username lowercases the username that is going to be used in a cache query.
+    fn normalize_username(username: &str) -> String {
+        username.to_lowercase()
+    }
 }

--- a/nss/src/cache/mod.rs
+++ b/nss/src/cache/mod.rs
@@ -435,7 +435,7 @@ impl CacheDB {
             "SELECT login, password, uid, gid, gecos, home, shell FROM passwd WHERE login = ?", // Last empty field is the shadow password
         )?;
 
-        let rows = match stmt.query([login]) {
+        let rows = match stmt.query([&Self::normalize_username(login)]) {
             Ok(rows) => rows,
             Err(err) => return Err(CacheError::QueryError(err.to_string())),
         };
@@ -501,7 +501,7 @@ impl CacheDB {
             ",
         )?;
 
-        let rows = match stmt.query([name]) {
+        let rows = match stmt.query([&Self::normalize_username(name)]) {
             Ok(rows) => rows,
             Err(err) => return Err(CacheError::QueryError(err.to_string())),
         };
@@ -551,7 +551,7 @@ impl CacheDB {
             "
         )?;
 
-        let rows = match stmt.query([name]) {
+        let rows = match stmt.query([&Self::normalize_username(name)]) {
             Ok(rows) => rows,
             Err(err) => return Err(CacheError::QueryError(err.to_string())),
         };

--- a/nss/src/group/mod_tests.rs
+++ b/nss/src/group/mod_tests.rs
@@ -88,6 +88,7 @@ fn test_get_entry_by_gid(
 }
 
 #[test_case("myuser@domain.com", Some("users_in_db".to_string()), -1, NssStatus::Success; "Successfully retrieves existing entry")]
+#[test_case("MyUser@Domain.Com", Some("users_in_db".to_string()), -1, NssStatus::Success; "Successfully retrieves existing entry with capitalized letters")]
 #[test_case("myuser@domain.com", Some("users_in_db".to_string()), 0, NssStatus::Success; "Successfully retrieves existing entry without access to shadow")]
 #[test_case("shadow", Some("users_in_db".to_string()), -1, NssStatus::NotFound; "Ignore non aad entry requests")]
 #[test_case("does not exist", Some("users_in_db".to_string()), -1, NssStatus::NotFound; "Error when entry does not exist")]

--- a/nss/src/group/testdata/test_get_entry_by_name/golden/successfully_retrieves_existing_entry_with_capitalized_letters
+++ b/nss/src/group/testdata/test_get_entry_by_name/golden/successfully_retrieves_existing_entry_with_capitalized_letters
@@ -1,0 +1,4 @@
+gid: '1929326240'
+members: myuser@domain.com
+name: myuser@domain.com
+passwd: x

--- a/nss/src/passwd/mod_tests.rs
+++ b/nss/src/passwd/mod_tests.rs
@@ -88,6 +88,7 @@ fn test_get_entry_by_uid(
 }
 
 #[test_case("myuser@domain.com", Some("users_in_db".to_string()), -1, NssStatus::Success; "Successfully retrieves existing entry")]
+#[test_case("MyUser@Domain.Com", Some("users_in_db".to_string()), -1, NssStatus::Success; "Successfully retrieves existing entry with capitalized letters")]
 #[test_case("myuser@domain.com", Some("users_in_db".to_string()), -1, NssStatus::Success; "Successfully retrieves existing entry without access to shadow")]
 #[test_case("does not exist", Some("users_in_db".to_string()), -1, NssStatus::NotFound; "Error when entry does not exist")]
 #[test_case("myuser@domain.com", Some("no_cache".to_string()), -1, NssStatus::Unavail; "Error when cache is not available")]

--- a/nss/src/passwd/testdata/test_get_entry_by_name/golden/successfully_retrieves_existing_entry_with_capitalized_letters
+++ b/nss/src/passwd/testdata/test_get_entry_by_name/golden/successfully_retrieves_existing_entry_with_capitalized_letters
@@ -1,0 +1,7 @@
+dir: /home/myuser@domain.com
+gecos: My User
+gid: '1929326240'
+name: myuser@domain.com
+passwd: x
+shell: /bin/bash
+uid: '1929326240'

--- a/nss/src/shadow/mod_tests.rs
+++ b/nss/src/shadow/mod_tests.rs
@@ -52,7 +52,9 @@ fn test_get_all_entries(
 }
 
 #[test_case("myuser@domain.com", Some("users_in_db".to_string()), 1, NssStatus::Success; "Successfully retrieves existing entry in RO mode")]
+#[test_case("MyUser@Domain.Com", Some("users_in_db".to_string()), -1, NssStatus::Success; "Successfully retrieves existing entry with capitalized letters in RO mode")]
 #[test_case("myuser@domain.com", Some("users_in_db".to_string()), 2, NssStatus::Success; "Successfully retrieves existing entry in RW mode")]
+#[test_case("MyUser@Domain.Com", Some("users_in_db".to_string()), -1, NssStatus::Success; "Successfully retrieves existing entry with capitalized letters in RW mode")]
 #[test_case("does not exist", Some("users_in_db".to_string()), 1, NssStatus::NotFound; "Error when entry does not exist")]
 #[test_case("myuser@domain.com", Some("no_cache".to_string()), 1, NssStatus::Unavail; "Error when cache is not available")]
 #[test_case("myuser@domain.com", Some("users_in_db".to_string()), 0, NssStatus::Unavail; "Error when shadow is not available")]

--- a/nss/src/shadow/testdata/test_get_entry_by_name/golden/successfully_retrieves_existing_entry_with_capitalized_letters_in_ro_mode
+++ b/nss/src/shadow/testdata/test_get_entry_by_name/golden/successfully_retrieves_existing_entry_with_capitalized_letters_in_ro_mode
@@ -1,0 +1,9 @@
+change_inactive_days: '-1'
+change_max_days: '-1'
+change_min_days: '-1'
+change_warn_days: '-1'
+expire_date: '-1'
+last_change: '-1'
+name: myuser@domain.com
+passwd: '*'
+reserved: RESERVED

--- a/nss/src/shadow/testdata/test_get_entry_by_name/golden/successfully_retrieves_existing_entry_with_capitalized_letters_in_rw_mode
+++ b/nss/src/shadow/testdata/test_get_entry_by_name/golden/successfully_retrieves_existing_entry_with_capitalized_letters_in_rw_mode
@@ -1,0 +1,9 @@
+change_inactive_days: '-1'
+change_max_days: '-1'
+change_min_days: '-1'
+change_warn_days: '-1'
+expire_date: '-1'
+last_change: '-1'
+name: myuser@domain.com
+passwd: '*'
+reserved: RESERVED


### PR DESCRIPTION
We normalize the username during the authentication and add the normalized version to the cache. This creates problems when the NSS module gets queried for the added entry later in the stack (by modules such as `pam-gkr`) since we don't update the username in the pam handler.

This PR updates our NSS getXXbyname queries to also normalize the username before actually querying the database so that it properly matches the entry that was added in our PAM module.

Closes #290 
UDENG-1055 