### PR TITLE
Fix FTBFS due to missing new required symbol

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,12 @@
+aad-auth (0.5.1) mantic; urgency=medium
+
+  * Fix FTBFS due to missing new required symbol
+
+ -- Denison Barbosa <denison.barbosa@canonical.com>  Fri, 18 Aug 2023 06:24:12 -0400
+
 aad-auth (0.5) mantic; urgency=medium
 
+  * New release (LP: #2031534)
   * Update Go version to 1.20
   * Update MSAL version to 1.1
   * Specify default scopes for authentication

--- a/debian/libpam-aad.symbols
+++ b/debian/libpam-aad.symbols
@@ -29,3 +29,4 @@ pam_aad.so libpam-aad #MINVER#
  (regex|optional)"sqlite3_*" 0.1
  (regex|optional)"x_cgo.*" 0.1
  (regex|optional)"_cgo.*" 0.1
+ x_crosscall2_ptr@Base 0.5


### PR DESCRIPTION
Golang 1.21 introduced a new required symbol `x_crosscall2_ptr` so we need to update the `libpam-aad.symbols` file to prevent FTBFS.