### PR TITLE
Go 1.21.0 is the real released Go version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ubuntu/aad-auth
 
-go 1.21
+go 1.21.0
 
 require (
 	github.com/AzureAD/microsoft-authentication-library-for-go v1.1.1

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/ubuntu/aad-auth/tools
 
-go 1.18
+go 1.21.0
 
 require github.com/golangci/golangci-lint v1.54.2
 


### PR DESCRIPTION
Go 1.21 is any unreleased version of Go tip until first rc. The real first release starting with 1.21 series is 1.21.0. https://go.dev/doc/toolchain.