### PR TITLE
Update changelog for 0.5.2 release

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -4,12 +4,14 @@ aad-auth (0.5.2) mantic; urgency=medium
     - This is not a new feature breakage. The previous build introduced
       a new symbol required by golang-go-1.21, so we need to bump the
       minimal required Go version to 1.21.
-  * Update MSAL version to 1.1.1
+  * Update MSAL version to 1.2.0
   * Update dependencies to latest:
     ** Rust
       - cc
       - libnss
       - time
+    ** Go
+      - golang.org/x/sys
   * Clean up some packaging steps
     - Some workarounds were necessary due to unmerged upstream changes. Now
       the fixes are merged and released, so packaging could be cleaned up.


### PR DESCRIPTION
MSAL released the 1.2 version before we released aad-auth 0.5.2, so we can integrate the MSAL bump into this version before pushing it.

Builds can be checked at: https://launchpad.net/~justdenis/+archive/ubuntu/mantic-aad-proposed/+packages

UDENG-1245