### PR TITLE
Passwddb locking fix (nss_aad: database error: database is locked)

### DIFF
--- a/internal/cache/cachedb.go
+++ b/internal/cache/cachedb.go
@@ -3,6 +3,7 @@ package cache
 import (
 	"context"
 	"database/sql"
+
 	// needed to embed the sql files for the creation of the cache db.
 	_ "embed"
 	"errors"
@@ -25,6 +26,7 @@ const (
 	defaultCachePath = "/var/lib/aad/cache"
 	passwdDB         = "passwd.db" // root:root 644
 	shadowDB         = "shadow.db" // root:shadow 640
+	db_con_args      = "?_journal_mode=wal"
 )
 
 var (
@@ -105,7 +107,7 @@ func initDB(ctx context.Context, cacheDir string, rootUID, rootGID, shadowGID, f
 	}
 
 	// Open existing cache
-	db, err = sql.Open("sqlite3", passwdPath)
+	db, err = sql.Open("sqlite3", passwdPath+db_con_args)
 	if err != nil {
 		return nil, 0, err
 	}

--- a/internal/cache/cachedb.go
+++ b/internal/cache/cachedb.go
@@ -3,7 +3,6 @@ package cache
 import (
 	"context"
 	"database/sql"
-
 	// needed to embed the sql files for the creation of the cache db.
 	_ "embed"
 	"errors"

--- a/nss/src/cache/mod.rs
+++ b/nss/src/cache/mod.rs
@@ -296,12 +296,11 @@ impl CacheDBBuilder {
                 shadow_mode = ShadowMode::ReadWrite;
             }
         }
-        
+
         let open_flags = match shadow_mode {
             ShadowMode::ReadWrite => OpenFlags::SQLITE_OPEN_READ_WRITE,
             _ => OpenFlags::SQLITE_OPEN_READ_ONLY,
         };
-        
 
         let passwd_db = &db_path.join(PASSWD_DB);
         let passwd_db = passwd_db.to_str().unwrap();
@@ -321,6 +320,7 @@ impl CacheDBBuilder {
         // Attaches shadow to the connection if the shadow db is at least ReadOnly for the current user.
         if shadow_mode >= ShadowMode::ReadOnly {
             let shadow_db = shadow_db.to_str().unwrap();
+
             debug!("attaching shadow database");
             let stmt_str = format!("attach database '{shadow_db}' as shadow;");
             if let Err(err) = conn.execute_batch(&stmt_str) {


### PR DESCRIPTION
fix: nss_aad: database error: database is locked

ref: aad_auth[2196]: nss_aad: database error: database is locked

This adresses this, by using Write-ahead logging journaling mode when openening the database in ReadWrite mode, 
and opening the database immutable when opening it in ReadOnly mode.

