### PR TITLE
fix(ci): Update dependabot commit messages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,24 +3,37 @@
 
 version: 2
 updates:
-  - package-ecosystem: "gomod"
-    directory: "/" # Location of package manifests
-    schedule:
-      interval: "daily"
-
-  - package-ecosystem: "gomod"
-    directory: "/tools"
-    schedule:
-      interval: "daily"
-
+  # Infrastructure
+  ## GitHub Actions
   - package-ecosystem: "github-actions"
     # Workflow files stored in the
     # default location of `.github/workflows`
     directory: "/"
     schedule:
       interval: "daily"
+    commit-message:
+      prefix: "deps(ci)"
 
+  # Codebase
+  ## Go dependencies
+  - package-ecosystem: "gomod"
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "daily"
+    commit-message:
+      prefix: "deps(go)"
+
+  - package-ecosystem: "gomod"
+    directory: "/tools"
+    schedule:
+      interval: "daily"
+    commit-message:
+      prefix: "deps(go-tools)"
+
+  ## Rust dependencies
   - package-ecosystem: "cargo"
     directory: "/"
     schedule:
       interval: "daily"
+    commit-message:
+      prefix: "deps(rust)"


### PR DESCRIPTION
We have established some conventional PR naming on our projects and updated Dependabot to do the same. This PR applies the mentioned change to this repo as well.