### PR TITLE
deps(go): bump Go to 1.21.4 to prevent sec vulnerabilities

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ubuntu/aad-auth
 
-go 1.21.0
+go 1.21.4
 
 require (
 	github.com/AzureAD/microsoft-authentication-library-for-go v1.2.0


### PR DESCRIPTION
Checker failed on security vulnerabilities fixed in 1.21.1 to 1.21.4