### PR TITLE
Add `min_uid` and `max_uid` configuration values.

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,13 @@ The [default template](https://github.com/ubuntu/aad-auth/blob/main/conf/aad.con
 #                    ; %d - domain
 # shell = /bin/bash ; default shell for the user
 
+## UID range configuration
+## WARNING! Changing these values may effect existing users.
+min_uid = 100000 ; minimum UID to assign (inclusive)
+max_uid = 2147483647 ; maximum UID to assign (exclusive)
+                     ; the default max_uid is 4294967295 (max uint32), however this causes issues with commonly used software, such as xdg-desktop-portal-gnome
+                     ; this value (max int32) works with most software, while still providing a large UID space.
+
 ### overriding values for a specific domain, every value inside a section is optional
 # [domain.com]
 # tenant_id = aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa

--- a/conf/aad.conf.template
+++ b/conf/aad.conf.template
@@ -16,6 +16,13 @@
 #                    ; %d - domain
 # shell = /bin/bash ; default shell for the user
 
+## UID range configuration
+## WARNING! Changing these values may effect existing users.
+min_uid = 100000 ; minimum UID to assign (inclusive)
+max_uid = 2147483647 ; maximum UID to assign (exclusive)
+                     ; the default max_uid is 4294967295 (max uint32), however this causes issues with commonly used software, such as xdg-desktop-portal-gnome
+                     ; this value (max int32) works with most software, while still providing a large UID space.
+
 ### overriding values for a specific domain, every value inside a section is optional
 # [domain.com]
 # tenant_id = aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa

--- a/internal/cache/cache_uid_test.go
+++ b/internal/cache/cache_uid_test.go
@@ -1,0 +1,9 @@
+package cache
+
+import (
+	"context"
+)
+
+func (c *Cache) GenerateUIDForUser(ctx context.Context, username string, minUID, maxUID uint32) (uint32, error) {
+	return c.generateUIDForUser(ctx, username, minUID, maxUID)
+}

--- a/internal/pam/pam.go
+++ b/internal/pam/pam.go
@@ -107,7 +107,7 @@ func Authenticate(ctx context.Context, username, password, conf string, opts ...
 	}
 
 	// Successful online login, update cache.
-	if err := c.Update(ctx, username, password, cfg.HomeDirPattern, cfg.Shell); err != nil {
+	if err := c.Update(ctx, username, password, cfg.HomeDirPattern, cfg.Shell, cfg.MinUID, cfg.MaxUID); err != nil {
 		logError(ctx, i18n.G("%w. Denying access."), err)
 		return ErrPamAuth
 	}


### PR DESCRIPTION
aad-auth assigns users to UIDs which are too large for some common software.

There are many reports of this problem, notably relating to xdg-desktop-portal-gnome not working:

- In https://github.com/ubuntu/aad-auth/issues/278, screensharing does not work because the portal is not loaded.
  - We have also had this problem.
- In https://github.com/ubuntu/aad-auth/issues/200, applications take excessively long to open.
  - We have experienced this issue with a variety of apps, including the nmapplet, gnome-terminal, and chromium.
- In https://github.com/ubuntu/aad-auth/issues/441 brings up exactly this issue, but hasn't had a response.

Adding a `min_uid` and `max_uid` configuration option allows the user to specify the range in which UIDs should be generated, thereby enabling admins to cap the UIDs at a range which works with most software.

To prevent existing installations from changing their behaviour, the default values, when the parameters aren't specified in the configuration file, remain at `100000` and `math.MaxUint32`, however the config template now explicitly sets the values to values which play nicely with xdg-desktop-portal-gnome, in an attempt to give new users a better experience.

Also, when a collision is found, instead of only incrementing the UID, which may overflow and end up as UID 0 (root!!!), we instead wrap around only within the specified range.