### PR TITLE
Issue: #191, allow selecting Azure GCC High environment via aad.conf

### DIFF
--- a/internal/aad/aad.go
+++ b/internal/aad/aad.go
@@ -15,8 +15,6 @@ import (
 )
 
 const (
-	endpoint = "https://login.microsoftonline.com"
-
 	invalidCredCode    = 50126
 	requiresMFACode    = 50076
 	noSuchUserCode     = 50034
@@ -25,6 +23,8 @@ const (
 )
 
 var (
+	endpoint = "https://login.microsoftonline.com"
+
 	// ErrNoNetwork is returned in case of no network available.
 	ErrNoNetwork = errors.New("NO NETWORK")
 	// ErrDeny is returned in case of denial returned by AAD.
@@ -46,6 +46,9 @@ type AAD struct {
 
 // Authenticate tries to authenticate username against AAD.
 func (auth AAD) Authenticate(ctx context.Context, cfg config.AAD, username, password string) error {
+	if cfg.AzureEnvironment == "GCC-H" {
+		endpoint = "https://login.microsoftonline.us"
+	}
 	authority := fmt.Sprintf("%s/%s", endpoint, cfg.TenantID)
 	logger.Debug(ctx, "Connecting to %q, with clientID %q for user %q", authority, cfg.AppID, username)
 
@@ -104,7 +107,7 @@ func (auth AAD) Authenticate(ctx context.Context, cfg config.AAD, username, pass
 
 		logger.Debug(ctx, "For more information about the error code(s), see:")
 		for _, errcode := range addErrWithCodes.ErrorCodes {
-			logger.Debug(ctx, "- Error code %d: https://login.microsoftonline.com/error?code=%d", errcode, errcode)
+			logger.Debug(ctx, "- Error code %d: %s/error?code=%d", errcode, endpoint, errcode)
 		}
 
 		return ErrDeny

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -94,10 +94,18 @@ func Load(ctx context.Context, p, domain string, opts ...Option) (config AAD, er
 	if config.AppID == "" {
 		return AAD{}, fmt.Errorf("missing required 'app_id' entry in configuration file")
 	}
+
 	if config.AzureEnvironment == "" {
 		config.AzureEnvironment = "Commercial"
 	}
-
+	switch config.AzureEnvironment {
+	case "Commercial":
+                logger.Debug(ctx, "Using Azure Commercial environment")
+	case "GCC-H":
+                logger.Debug(ctx, "Using Azure GCC-H environment")
+	default:
+		return AAD{}, fmt.Errorf("unknown value '%s' for 'azure_environment'", config.AzureEnvironment)
+	}
 	return config, nil
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -23,6 +23,7 @@ const (
 type AAD struct {
 	TenantID                     string `ini:"tenant_id"`
 	AppID                        string `ini:"app_id"`
+	AzureEnvironment             string `ini:"azure_environment"`
 	OfflineCredentialsExpiration *int   `ini:"offline_credentials_expiration"`
 	HomeDirPattern               string `ini:"homedir"`
 	Shell                        string `ini:"shell"`
@@ -92,6 +93,9 @@ func Load(ctx context.Context, p, domain string, opts ...Option) (config AAD, er
 	}
 	if config.AppID == "" {
 		return AAD{}, fmt.Errorf("missing required 'app_id' entry in configuration file")
+	}
+	if config.AzureEnvironment == "" {
+		config.AzureEnvironment = "Commercial"
 	}
 
 	return config, nil


### PR DESCRIPTION
This PR extends functionality to allow the "azure_environment" directive in aad.conf to select Commercial or GCC-H Azure environments, updating the login endpoint appropriately. It defaults to Commercial if the variable is not set, so it should be backwards compatible.

This can easily be extended to support other environments as well, but I only have Commercial and GCC-H to test.